### PR TITLE
New api fields

### DIFF
--- a/original/installer/constants/versions.py
+++ b/original/installer/constants/versions.py
@@ -56,6 +56,3 @@ XMIPP_VERSIONS = {
 	}																	
 }																		
 #####################################
-
-# Other variables
-UNKNOWN_VALUE = 'Unknown'

--- a/src/xmipp3_installer/api_client/api_client.py
+++ b/src/xmipp3_installer/api_client/api_client.py
@@ -20,16 +20,20 @@ def send_installation_attempt(installation_info: Dict):
 	params = json.dumps(installation_info)
 	headers = {"Content-type": "application/json"}
 	parsed_url = urlparse(urls.API_URL)
+	conn = None
 	try:
 		conn = __get_https_connection(parsed_url, 2)
 		conn.request("POST", parsed_url.path, body=params, headers=headers)
 		conn.getresponse()
-		conn.close()
 	except TimeoutError:
 		logger(
 			logger.yellow("There was a timeout while sending installation data."),
 			show_in_terminal=False
 		)
+	finally:
+		if conn is not None:
+			conn.close()
+
 
 def __get_https_connection(parsed_url: ParseResult, timeout_seconds: int) -> http.client.HTTPSConnection:
 	"""

--- a/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
+++ b/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import re
+import os
 from typing import Optional, List, Dict
 
 from xmipp3_installer.installer import constants
@@ -33,6 +34,7 @@ def get_installation_info(ret_code: int=0) -> Optional[Dict]:
 			__get_cpu_flags,
 			git_handler.get_current_branch,
 			git_handler.is_branch_up_to_date,
+			__is_installed_by_scipion,
 			__get_log_tail
 		],
 		[(), (), (), (), ()]
@@ -58,10 +60,11 @@ def get_installation_info(ret_code: int=0) -> Optional[Dict]:
 		},
 		"xmipp": {
 			"branch": __get_installation_branch_name(environment_info[2]),
-			"updated": environment_info[3]
+			"updated": environment_info[3],
+			"installedByScipion": environment_info[4]
 		},
 		"returnCode": ret_code,
-		"logTail": environment_info[4] if ret_code else None # Only needed if something went wrong
+		"logTail": environment_info[5] if ret_code else None # Only needed if something went wrong
 	}
 
 def get_os_release_name() -> str:
@@ -166,3 +169,12 @@ def __find_mac_address_in_lines(lines: List[str]) -> Optional[str]:
 				lines[line_index + 1]
 			).group(1)
 	return None
+
+def __is_installed_by_scipion() -> bool:
+	"""
+	### Checks if the current xmipp installation is being carried out from Scipion.
+
+	#### Returns:
+	- (bool): True if the installation is executed by Scipion, False otherwise.
+	"""
+	return bool(os.getenv("SCIPION_SOFTWARE"))

--- a/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
+++ b/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
@@ -73,10 +73,10 @@ def get_os_release_name() -> str:
 	"""
 	ret_code, os_release_info = shell_handler.run_shell_command('cat /etc/os-release')
 	if ret_code:
-		return constants.UNKNOWN_VALUE
+		return None
 	
 	search = re.search(r'PRETTY_NAME="(.*)"\n', os_release_info)
-	return search.group(1) if search else constants.UNKNOWN_VALUE
+	return search.group(1) if search else None
 
 def __get_installation_branch_name(branch_name: str) -> str:
 	"""

--- a/src/xmipp3_installer/installer/constants.py
+++ b/src/xmipp3_installer/installer/constants.py
@@ -20,4 +20,3 @@ CONFIG_FILE = 'xmipp.conf'
 
 # Others
 TAIL_LOG_NCHARS = 300
-UNKNOWN_VALUE = 'Unknown'

--- a/tests/integration/api_client/api_client_test.py
+++ b/tests/integration/api_client/api_client_test.py
@@ -19,7 +19,7 @@ def test_records_api_call_when_sending_installation_attempt(
 	__mock_library_versions_file,
 	__mock_run_parallel_jobs,
 	__mock_get_release_name,
-	__mock_get_architecture_name,
+	__mock_get_cpu_flags,
 	__mock_get_current_branch,
 	__mock_is_branch_up_to_date,
 	__mock_log_tail,
@@ -70,10 +70,10 @@ def __mock_get_release_name(fake_process):
 	yield fake_process
 
 @pytest.fixture
-def __mock_get_architecture_name(fake_process):
+def __mock_get_cpu_flags(fake_process):
 	fake_process.register_subprocess(
-		shlex.split("cat /sys/devices/cpu/caps/pmu_name"),
-		stdout=shell_command_outputs.PMU_NAME
+		'lscpu | grep \"Flags:\"',
+		stdout=shell_command_outputs.LSCPU_FLAGS
 	)
 	yield fake_process
 

--- a/tests/integration/api_client/shell_command_outputs.py
+++ b/tests/integration/api_client/shell_command_outputs.py
@@ -29,7 +29,7 @@ REDHAT_BUGZILLA_PRODUCT_VERSION=8.10
 REDHAT_SUPPORT_PRODUCT=\"Red Hat Enterprise Linux\"
 REDHAT_SUPPORT_PRODUCT_VERSION=\"8.10\""""
 
-LSCPU = (
+LSCPU_FLAGS = (
   "Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov "
   "pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm "
   "constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni "

--- a/tests/integration/api_client/shell_command_outputs.py
+++ b/tests/integration/api_client/shell_command_outputs.py
@@ -29,4 +29,13 @@ REDHAT_BUGZILLA_PRODUCT_VERSION=8.10
 REDHAT_SUPPORT_PRODUCT=\"Red Hat Enterprise Linux\"
 REDHAT_SUPPORT_PRODUCT_VERSION=\"8.10\""""
 
-PMU_NAME = "skylake"
+LSCPU = (
+  "Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov "
+  "pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm "
+  "constant_tsc rep_good nopl nonstop_tsc cpuid extd_apicid aperfmperf tsc_known_freq pni "
+  "pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c "
+  "rdrand hypervisor lahf_lm cmp_legacy cr8_legacy abm sse4a misalignsse 3dnowprefetch "
+  "topoext invpcid_single ssbd ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 invpcid "
+  "rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 clzero xsaveerptr wbnoinvd "
+  "arat npt nrip_save vaes vpclmulqdq rdpid"
+)

--- a/tests/unitary/api_client/assembler/installation_info_assembler_test.py
+++ b/tests/unitary/api_client/assembler/installation_info_assembler_test.py
@@ -307,11 +307,11 @@ def test_calls_re_search_group_when_getting_os_release_name(
 @pytest.mark.parametrize(
   "__mock_run_shell_command,expected_release_name",
   [
-    pytest.param((1, ""), constants.UNKNOWN_VALUE),
-    pytest.param((1, "something"), constants.UNKNOWN_VALUE),
-    pytest.param((1, __RELEASE_OUPUT), constants.UNKNOWN_VALUE),
-    pytest.param((0, ""), constants.UNKNOWN_VALUE),
-    pytest.param((0, "something"), constants.UNKNOWN_VALUE),
+    pytest.param((1, ""), None),
+    pytest.param((1, "something"), None),
+    pytest.param((1, __RELEASE_OUPUT), None),
+    pytest.param((0, ""), None),
+    pytest.param((0, "something"), None),
     pytest.param((0, __RELEASE_OUPUT), __RELEASE_NAME)
   ],
   indirect=["__mock_run_shell_command"]


### PR DESCRIPTION
Also:
- Ensure API always closes connection when applicable.
- Set `None` (`null` in json format) as the default value for unkown.
- Added `installedByScipion` variable, which indicates if this Xmipp installation was carried out from Scipion.