### PR TITLE
Increased installation API call usage

### DIFF
--- a/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
+++ b/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
@@ -96,16 +96,16 @@ def __get_installation_branch_name(branch_name: str) -> str:
 	else:
 		return branch_name
 
-def __get_user_id() -> Optional[str]:
+def __get_user_id() -> str:
 	"""
 	### Returns the unique user id for this machine.
 	
 	#### Returns:
-	- (str | None): User id, or None if there were any errors.
+	- (str): User id, or 'Anoymous' if there were any errors.
 	"""
 	mac_address = __get_mac_address()
 	if not mac_address:
-		return
+		return "Anonymous"
 	
 	sha256 = hashlib.sha256()
 	sha256.update(mac_address.encode())

--- a/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
+++ b/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
@@ -24,10 +24,6 @@ def get_installation_info(ret_code: int=0) -> Optional[Dict]:
 	#### Return:
 	- (dict | None): Dictionary with the required info or None if user id could not be produced.
 	"""
-	user_id = __get_user_id()
-	if user_id is None:
-		return
-	
 	library_versions = cmake_handler.get_library_versions_from_cmake_file(
 		constants.LIBRARY_VERSIONS_FILE
 	)
@@ -44,7 +40,7 @@ def get_installation_info(ret_code: int=0) -> Optional[Dict]:
 
 	return {
 		"user": {
-			"userId": user_id
+			"userId": __get_user_id()
 		},
 		"version": {
 			"os": get_os_release_name(),
@@ -159,11 +155,11 @@ def __find_mac_address_in_lines(lines: List[str]) -> Optional[str]:
 	"""
 	for line_index in range(len(lines) - 1):
 		line = lines[line_index]
-		match = re.match(r"^\d+: (enp|wlp|eth)\w+", line)
+		match = re.match(r"^\d+: (enp|wlp|eth|ens)\w+", line)
 		if not match:
 			continue
 		interface_name = match.group(1)
-		if interface_name.startswith(('enp', 'wlp', 'eth')):
+		if interface_name.startswith(('enp', 'wlp', 'eth', 'ens')):
 			return re.search(
 				r"link/ether ([0-9a-f:]{17})",
 				lines[line_index + 1]

--- a/tests/unitary/api_client/assembler/installation_info_assembler_test.py
+++ b/tests/unitary/api_client/assembler/installation_info_assembler_test.py
@@ -107,6 +107,7 @@ __EMPTY_INSTALLATION_INFO = {
   "returnCode": 0,
   "logTail": None
 }
+__DEFAULT_USER_ID = "Anonymous"
 
 def test_calls_run_shell_command_when_getting_cpu_flags(__mock_run_shell_command):
   installation_info_assembler.__get_cpu_flags()
@@ -294,8 +295,8 @@ def test_calls_hashlib_sha256_hexdigest_when_getting_user_id(
 @pytest.mark.parametrize(
   "__mock_get_mac_address,__mock_hashlib_sha256,expected_user_id",
   [
-    pytest.param(None, None, None),
-    pytest.param(None, "test-id", None),
+    pytest.param(None, None, __DEFAULT_USER_ID),
+    pytest.param(None, "test-id", __DEFAULT_USER_ID),
     pytest.param(__ETH_MAC_ADDRESS, None, None),
     pytest.param(__ETH_MAC_ADDRESS, "test-id", "test-id")
   ],


### PR DESCRIPTION
- Now when the MAC could not be recognized, "Anonymous" is sent instead of None (which previously avoided the call to happen, while now it will happen regardless with an anonymous hive user).
- In AWS EC2 instances, network interfaces start with `ens`, so this characters are also added to the detection of the network interface.