### PR TITLE
Remove extra sources (leaving only xmippCore)

### DIFF
--- a/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
+++ b/src/xmipp3_installer/api_client/assembler/installation_info_assembler.py
@@ -87,8 +87,8 @@ def __get_installation_branch_name(branch_name: str) -> str:
 	#### Return:
 	- (str): Release name if Xmipp is in a release branch, or the branch name otherwise.
 	"""
-	if not branch_name or branch_name == versions.MASTER_BRANCHNAME:
-		return versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY]
+	if not branch_name or branch_name == constants.MASTER_BRANCHNAME:
+		return versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]
 	else:
 		return branch_name
 

--- a/src/xmipp3_installer/application/logger/predefined_messages.py
+++ b/src/xmipp3_installer/application/logger/predefined_messages.py
@@ -1,4 +1,5 @@
 from xmipp3_installer.application.logger.logger import logger
+from xmipp3_installer.installer import constants
 from xmipp3_installer.installer.handlers import git_handler
 from xmipp3_installer.installer.tmp import versions
 
@@ -51,7 +52,7 @@ def get_success_message() -> str:
 	#### Returms:
 	- (str): Success message.
 	"""
-	tag_version = versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY]
+	tag_version = versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]
 	release_name = tag_version if git_handler.is_tag() else git_handler.get_current_branch()
 
 	box_wrapper = '*  *'

--- a/src/xmipp3_installer/installer/constants.py
+++ b/src/xmipp3_installer/installer/constants.py
@@ -21,6 +21,7 @@ LOG_FILE = 'compilation.log'
 LIBRARY_VERSIONS_FILE = os.path.join(BUILD_PATH, 'versions.txt')
 CONFIG_FILE = 'xmipp.conf'
 SCIPION_SOFTWARE_EM = os.path.join("scipionfiles", "downloads", "scipion", "software", "em")
+XMIPP_CORE_PATH = os.path.join(SOURCES_PATH, XMIPP_CORE)
 
 # Others
 TAIL_LOG_NCHARS = 300

--- a/src/xmipp3_installer/installer/constants.py
+++ b/src/xmipp3_installer/installer/constants.py
@@ -7,7 +7,7 @@ import os
 XMIPP_CORE = 'xmippCore'
 XMIPP_VIZ = 'xmippViz'
 XMIPP_PLUGIN = 'scipion-em-xmipp'
-XMIPP_SOURCES = [XMIPP_CORE, XMIPP_VIZ, XMIPP_PLUGIN]
+XMIPP_SOURCES = [XMIPP_CORE, XMIPP_VIZ]
 
 # Paths
 SOURCES_PATH = "src"

--- a/src/xmipp3_installer/installer/constants.py
+++ b/src/xmipp3_installer/installer/constants.py
@@ -3,9 +3,13 @@
 import os
 
 # Repository names
-#XMIPP = 'xmipp'
+XMIPP = 'xmipp'
 XMIPP_CORE = 'xmippCore'
 XMIPP_SOURCES = [XMIPP_CORE]
+
+# Branch names
+DEVEL_BRANCHNAME = 'devel'
+MASTER_BRANCHNAME = 'master'
 
 # Paths
 SOURCES_PATH = "src"
@@ -16,7 +20,7 @@ INSTALL_PATH = "dist"
 LOG_FILE = 'compilation.log'
 LIBRARY_VERSIONS_FILE = os.path.join(BUILD_PATH, 'versions.txt')
 CONFIG_FILE = 'xmipp.conf'
-SCIPION_SOFTWARE_EM = "scipionfiles/downloads/scipion/software/em"
+SCIPION_SOFTWARE_EM = os.path.join("scipionfiles", "downloads", "scipion", "software", "em")
 
 # Others
 TAIL_LOG_NCHARS = 300

--- a/src/xmipp3_installer/installer/constants.py
+++ b/src/xmipp3_installer/installer/constants.py
@@ -5,9 +5,7 @@ import os
 # Repository names
 #XMIPP = 'xmipp'
 XMIPP_CORE = 'xmippCore'
-XMIPP_VIZ = 'xmippViz'
-XMIPP_PLUGIN = 'scipion-em-xmipp'
-XMIPP_SOURCES = [XMIPP_CORE, XMIPP_VIZ]
+XMIPP_SOURCES = [XMIPP_CORE]
 
 # Paths
 SOURCES_PATH = "src"

--- a/src/xmipp3_installer/installer/constants.py
+++ b/src/xmipp3_installer/installer/constants.py
@@ -5,7 +5,6 @@ import os
 # Repository names
 XMIPP = 'xmipp'
 XMIPP_CORE = 'xmippCore'
-XMIPP_SOURCES = [XMIPP_CORE]
 
 # Branch names
 DEVEL_BRANCHNAME = 'devel'

--- a/src/xmipp3_installer/installer/modes/mode_clean/mode_clean_all_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_clean/mode_clean_all_executor.py
@@ -14,10 +14,7 @@ class ModeCleanAllExecutor(mode_clean_executor.ModeCleanExecutor):
 		- (list(str)): List containing all the paths to delete.
 		"""
 		return [
-			*[
-				os.path.join(constants.SOURCES_PATH, source)
-				for source in constants.XMIPP_SOURCES
-			],
+			os.path.join(constants.SOURCES_PATH, constants.XMIPP_CORE),
 			constants.INSTALL_PATH,
 			constants.BUILD_PATH,
 			constants.CONFIG_FILE

--- a/src/xmipp3_installer/installer/modes/mode_clean/mode_clean_all_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_clean/mode_clean_all_executor.py
@@ -14,7 +14,7 @@ class ModeCleanAllExecutor(mode_clean_executor.ModeCleanExecutor):
 		- (list(str)): List containing all the paths to delete.
 		"""
 		return [
-			os.path.join(constants.SOURCES_PATH, constants.XMIPP_CORE),
+			constants.XMIPP_CORE_PATH,
 			constants.INSTALL_PATH,
 			constants.BUILD_PATH,
 			constants.CONFIG_FILE

--- a/src/xmipp3_installer/installer/modes/mode_clean/mode_clean_bin_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_clean/mode_clean_bin_executor.py
@@ -74,7 +74,7 @@ class ModeCleanBinExecutor(mode_clean_executor.ModeCleanExecutor):
 		"""
 		empty_dirs = [] 
 		for root, dirs, files in os.walk(os.path.join(
-			constants.SOURCES_PATH, versions.XMIPP, "applications", "programs"
+			constants.SOURCES_PATH, constants.XMIPP, "applications", "programs"
 		)): 
 			if not len(dirs) and not len(files): 
 				empty_dirs.append(root) 

--- a/src/xmipp3_installer/installer/modes/mode_version_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_version_executor.py
@@ -47,7 +47,7 @@ class ModeVersionExecutor(mode_executor.ModeExecutor):
 			library_file_exists = os.path.exists(constants.LIBRARY_VERSIONS_FILE)
 			if library_file_exists:
 				logger(f"\n{self.__get_library_versions_section()}")
-			if not ModeVersionExecutor.__are_all_sources_present() or not library_file_exists:
+			if not os.path.exists(constants.XMIPP_CORE_PATH) or not library_file_exists:
 				logger(f"\n{self.__get_configuration_warning_message()}")
 		return 0, ""
 
@@ -130,19 +130,6 @@ class ModeVersionExecutor(mode_executor.ModeExecutor):
 			library_left_text = self.__add_padding_spaces(f"{library}: ")
 			version_lines.append(f"{library_left_text}{version}")
 		return '\n'.join(version_lines)
-
-	@staticmethod
-	def __are_all_sources_present() -> bool:
-		"""
-		### Check if all required source packages are present.
-
-		#### Returns:
-		- (bool): True if all source packages are present, False otherwise.
-		"""
-		for source_package in constants.XMIPP_SOURCES:
-			if not os.path.exists(os.path.join(constants.SOURCES_PATH, source_package)):
-				return False
-		return True
 
 	def __get_configuration_warning_message(self) -> str:
 		"""

--- a/src/xmipp3_installer/installer/modes/mode_version_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_version_executor.py
@@ -34,22 +34,34 @@ class ModeVersionExecutor(mode_executor.ModeExecutor):
 		#### Returns:
 		- (tuple(int, str)): Tuple containing the error status and an error message if there was an error.
 		"""
-		if self.short:
-			logger(versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERNAME_KEY])
-		else:
-			version_type = 'release' if git_handler.is_tag() else git_handler.get_current_branch()
-			title = f"Xmipp {versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]} ({version_type})"
-			logger(f"{logger.bold(title)}\n")
-			logger(self.__get_dates_section())
-			system_version_left_text = self.__add_padding_spaces("System version: ")
-			logger(f"{system_version_left_text}{installation_info_assembler.get_os_release_name()}")
-			logger(self.__get_xmipp_core_info())
-			library_file_exists = os.path.exists(constants.LIBRARY_VERSIONS_FILE)
-			if library_file_exists:
-				logger(f"\n{self.__get_library_versions_section()}")
-			if not os.path.exists(constants.XMIPP_CORE_PATH) or not library_file_exists:
-				logger(f"\n{self.__get_configuration_warning_message()}")
+		installation_info = (
+			versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERNAME_KEY]
+			if self.short else self.__get_long_version()
+		)
+		logger(installation_info)
 		return 0, ""
+
+	def __get_long_version(self) -> str:
+		"""
+		### Returns the long version of the installation info.
+
+		#### Returns:
+		- (str): Long version of the installation info.
+		"""
+		installation_info_lines = []
+		version_type = 'release' if git_handler.is_tag() else git_handler.get_current_branch()
+		title = f"Xmipp {versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]} ({version_type})"
+		installation_info_lines.append(f"{logger.bold(title)}\n")
+		installation_info_lines.append(self.__get_dates_section())
+		system_version_left_text = self.__add_padding_spaces("System version: ")
+		installation_info_lines.append(f"{system_version_left_text}{installation_info_assembler.get_os_release_name()}")
+		installation_info_lines.append(self.__get_xmipp_core_info())
+		library_file_exists = os.path.exists(constants.LIBRARY_VERSIONS_FILE)
+		if library_file_exists:
+			installation_info_lines.append(f"\n{self.__get_library_versions_section()}")
+		if not os.path.exists(constants.XMIPP_CORE_PATH) or not library_file_exists:
+			installation_info_lines.append(f"\n{self.__get_configuration_warning_message()}")
+		return '\n'.join(installation_info_lines)
 
 	def __get_dates_section(self) -> str:
 		"""

--- a/src/xmipp3_installer/installer/modes/mode_version_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_version_executor.py
@@ -43,7 +43,7 @@ class ModeVersionExecutor(mode_executor.ModeExecutor):
 			logger(self.__get_dates_section())
 			system_version_left_text = self.__add_padding_spaces("System version: ")
 			logger(f"{system_version_left_text}{installation_info_assembler.get_os_release_name()}")
-			logger(self.__get_sources_info())
+			logger(self.__get_xmipp_core_info())
 			library_file_exists = os.path.exists(constants.LIBRARY_VERSIONS_FILE)
 			if library_file_exists:
 				logger(f"\n{self.__get_library_versions_section()}")
@@ -67,36 +67,20 @@ class ModeVersionExecutor(mode_executor.ModeExecutor):
 			dates_section += "-"
 		return dates_section
 	
-	def __get_sources_info(self) -> str:
+	def __get_xmipp_core_info(self) -> str:
 		"""
-		### Returns the message section related to sources.
+		### Returns the info message related to xmippCore.
 
 		#### Returns:
-		- (str): Sources related message section.
+		- (str): Info message about xmippCore.
 		"""
-		sources_message_lines = []
-		for source_package in constants.XMIPP_SOURCES:
-			sources_message_lines.append(self.__get_source_info(source_package))
-		return '\n'.join(sources_message_lines)
-
-	def __get_source_info(self, source: str) -> str:
-		"""
-		### Returns the info message related to a given source.
-
-		#### Params:
-		- source (str): Source to get the message about.
-
-		#### Returns:
-		- (str): Info message about the given source.
-		"""
-		source_path = os.path.join(constants.SOURCES_PATH, source)
-		source_left_text = self.__add_padding_spaces(f"{source} branch: ")
-		if not os.path.exists(source_path):
+		source_left_text = self.__add_padding_spaces(f"{constants.XMIPP_CORE} branch: ")
+		if not os.path.exists(constants.XMIPP_CORE_PATH):
 			return f"{source_left_text}{logger.yellow('Not found')}"
-		current_commit = git_handler.get_current_commit(dir=source_path)
-		commit_branch = git_handler.get_commit_branch(current_commit, dir=source_path)
-		current_branch = git_handler.get_current_branch(dir=source_path)
-		display_name = commit_branch if git_handler.is_tag(dir=source_path) else current_branch
+		current_commit = git_handler.get_current_commit(dir=constants.XMIPP_CORE_PATH)
+		commit_branch = git_handler.get_commit_branch(current_commit, dir=constants.XMIPP_CORE_PATH)
+		current_branch = git_handler.get_current_branch(dir=constants.XMIPP_CORE_PATH)
+		display_name = commit_branch if git_handler.is_tag(dir=constants.XMIPP_CORE_PATH) else current_branch
 		return f"{source_left_text}{display_name} ({current_commit})"
 
 	def __add_padding_spaces(self, left_text: str) -> str:

--- a/src/xmipp3_installer/installer/modes/mode_version_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_version_executor.py
@@ -35,10 +35,10 @@ class ModeVersionExecutor(mode_executor.ModeExecutor):
 		- (tuple(int, str)): Tuple containing the error status and an error message if there was an error.
 		"""
 		if self.short:
-			logger(versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERNAME_KEY])
+			logger(versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERNAME_KEY])
 		else:
 			version_type = 'release' if git_handler.is_tag() else git_handler.get_current_branch()
-			title = f"Xmipp {versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY]} ({version_type})"
+			title = f"Xmipp {versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]} ({version_type})"
 			logger(f"{logger.bold(title)}\n")
 			logger(self.__get_dates_section())
 			system_version_left_text = self.__add_padding_spaces("System version: ")

--- a/src/xmipp3_installer/installer/tmp/versions.py
+++ b/src/xmipp3_installer/installer/tmp/versions.py
@@ -27,14 +27,6 @@ XMIPP_VERSIONS = {
 	XMIPP_CORE: {											
 		VERSION_KEY: __LATEST_RELEASE_NUMBER,				
 		VERNAME_KEY: __LATEST_RELEASE_NAME  
-	},																
-	XMIPP_VIZ: {											
-		VERSION_KEY: __LATEST_RELEASE_NUMBER,				
-		VERNAME_KEY: __LATEST_RELEASE_NAME  
-	},																
-	XMIPP_PLUGIN: {										
-		VERSION_KEY: __LATEST_RELEASE_NUMBER,				
-		VERNAME_KEY: __LATEST_RELEASE_NAME  
-	}																	
+	}
 }																		
 #####################################

--- a/src/xmipp3_installer/installer/tmp/versions.py
+++ b/src/xmipp3_installer/installer/tmp/versions.py
@@ -2,29 +2,19 @@
 Contains all version info required for Xmipp's installation process.
 """
 
+from xmipp3_installer.installer import constants
+
 #### THIS SHOULD BE LOCATED IN XMIPP'S REPOSITORY,
 #### AND BE RETRIEVED FROM THERE
-
-XMIPP = 'xmipp'
-XMIPP_CORE = 'xmippCore'
-XMIPP_VIZ = 'xmippViz'
-XMIPP_PLUGIN = 'scipion-em-xmipp'
 
 __LATEST_RELEASE_NUMBER = '3.XX.YY.0'
 __LATEST_RELEASE_NAME = 'v3.XX.YY-TBD'
 RELEASE_DATE = 'dd/mm/yyyy'
 #####################################
-DEVEL_BRANCHNAME = 'devel'					
-MASTER_BRANCHNAME = 'master'				
-																		
 VERSION_KEY = 'version'							
 VERNAME_KEY = 'vername'							
 XMIPP_VERSIONS = {									
-	XMIPP: {													
-		VERSION_KEY: __LATEST_RELEASE_NUMBER,				
-		VERNAME_KEY: __LATEST_RELEASE_NAME  
-	},																
-	XMIPP_CORE: {											
+	constants.XMIPP: {													
 		VERSION_KEY: __LATEST_RELEASE_NUMBER,				
 		VERNAME_KEY: __LATEST_RELEASE_NAME  
 	}

--- a/tests/e2e/mode_clean_all_test.py
+++ b/tests/e2e/mode_clean_all_test.py
@@ -5,15 +5,11 @@ import pytest
 
 from xmipp3_installer.application.cli.arguments import modes
 from xmipp3_installer.installer import constants
-from xmipp3_installer.installer.tmp import versions
 from xmipp3_installer.repository import file_operations
 
 from .. import get_assertion_message
 
-__SOURCES_PATHS = [
-  os.path.join(constants.SOURCES_PATH, source)
-  for source in constants.XMIPP_SOURCES
-]
+__CORE_SOURCE = os.path.join(constants.SOURCES_PATH, constants.XMIPP_CORE)
 
 @pytest.mark.parametrize(
   "confirmation_text",
@@ -35,7 +31,7 @@ def test_deletes_expected_files(__setup_environment, confirmation_text):
   )
   
   for remaining_path in [
-    *__SOURCES_PATHS,
+    __CORE_SOURCE,
     constants.INSTALL_PATH,
     constants.BUILD_PATH,
     constants.CONFIG_FILE
@@ -53,21 +49,17 @@ def __create_config_file():
   with open(constants.CONFIG_FILE, "w") as empty_file:
     empty_file.write("")
 
-def __generate_sources():
-  for source_path in __SOURCES_PATHS:
-    os.makedirs(source_path, exist_ok=True)
-
 @pytest.fixture
 def __setup_environment():
   try:
-    __generate_sources()
+    os.makedirs(__CORE_SOURCE, exist_ok=True)
     os.makedirs(constants.INSTALL_PATH, exist_ok=True)
     os.makedirs(constants.BUILD_PATH, exist_ok=True)
     __create_config_file()
     yield
   finally:
     file_operations.delete_paths([
-      *__SOURCES_PATHS,
+      __CORE_SOURCE,
       constants.INSTALL_PATH,
       constants.BUILD_PATH,
     ])

--- a/tests/e2e/mode_clean_all_test.py
+++ b/tests/e2e/mode_clean_all_test.py
@@ -9,8 +9,6 @@ from xmipp3_installer.repository import file_operations
 
 from .. import get_assertion_message
 
-__CORE_SOURCE = os.path.join(constants.SOURCES_PATH, constants.XMIPP_CORE)
-
 @pytest.mark.parametrize(
   "confirmation_text",
   [
@@ -31,7 +29,7 @@ def test_deletes_expected_files(__setup_environment, confirmation_text):
   )
   
   for remaining_path in [
-    __CORE_SOURCE,
+    constants.XMIPP_CORE_PATH,
     constants.INSTALL_PATH,
     constants.BUILD_PATH,
     constants.CONFIG_FILE
@@ -52,14 +50,14 @@ def __create_config_file():
 @pytest.fixture
 def __setup_environment():
   try:
-    os.makedirs(__CORE_SOURCE, exist_ok=True)
+    os.makedirs(constants.XMIPP_CORE_PATH, exist_ok=True)
     os.makedirs(constants.INSTALL_PATH, exist_ok=True)
     os.makedirs(constants.BUILD_PATH, exist_ok=True)
     __create_config_file()
     yield
   finally:
     file_operations.delete_paths([
-      __CORE_SOURCE,
+      constants.XMIPP_CORE_PATH,
       constants.INSTALL_PATH,
       constants.BUILD_PATH,
     ])

--- a/tests/e2e/mode_clean_bin_test.py
+++ b/tests/e2e/mode_clean_bin_test.py
@@ -19,7 +19,7 @@ __O_FILE = os.path.join(__COMPILATION_FILES_DIR, "test.o")
 __DUMMY_FILE = os.path.join(__COMPILATION_FILES_DIR, "dummy_file")
 __DIR_STRUCT_ROOT = os.path.join(
   constants.SOURCES_PATH,
-  versions.XMIPP,
+  constants.XMIPP,
   "applications",
   "programs"
 )
@@ -101,7 +101,7 @@ def __setup_environment():
   finally:
     file_operations.delete_paths([
       __COMPILATION_FILES_DIR,
-      os.path.join(constants.SOURCES_PATH, versions.XMIPP),
+      os.path.join(constants.SOURCES_PATH, constants.XMIPP),
       __DBLITE_FILE,
       __PYCACHE_ROOT,
       constants.BUILD_PATH

--- a/tests/e2e/mode_version_test.py
+++ b/tests/e2e/mode_version_test.py
@@ -16,7 +16,7 @@ from .. import (
 def test_returns_short_version():
 	command_words = ["xmipp3_installer", modes.MODE_VERSION, "--short"]
 	result = subprocess.run(command_words, capture_output=True, text=True)
-	expected_version = f"{versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERNAME_KEY]}\n"
+	expected_version = f"{versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERNAME_KEY]}\n"
 	assert (
 		result.stdout == expected_version
 	), get_assertion_message("short version", expected_version, result.stdout)

--- a/tests/e2e/mode_version_test.py
+++ b/tests/e2e/mode_version_test.py
@@ -13,8 +13,6 @@ from .. import (
 	get_assertion_message, copy_file_from_reference, get_test_file
 )
 
-__CORE_SOURCE = os.path.join(constants.SOURCES_PATH, constants.XMIPP_CORE)
-
 def test_returns_short_version():
 	command_words = ["xmipp3_installer", modes.MODE_VERSION, "--short"]
 	result = subprocess.run(command_words, capture_output=True, text=True)
@@ -61,10 +59,10 @@ def __setup_evironment(request):
 				constants.LIBRARY_VERSIONS_FILE
 			)
 		if not sources_exist:
-			file_operations.delete_paths([__CORE_SOURCE])
+			file_operations.delete_paths([constants.XMIPP_CORE_PATH])
 		else:
-			os.makedirs(__CORE_SOURCE, exist_ok=True)
+			os.makedirs(constants.XMIPP_CORE_PATH, exist_ok=True)
 		yield lib_file_exist, sources_exist
 	finally:
 		__delete_library_versions_file()
-		file_operations.delete_paths([__CORE_SOURCE])
+		file_operations.delete_paths([constants.XMIPP_CORE_PATH])

--- a/tests/e2e/mode_version_test.py
+++ b/tests/e2e/mode_version_test.py
@@ -13,6 +13,8 @@ from .. import (
 	get_assertion_message, copy_file_from_reference, get_test_file
 )
 
+__CORE_SOURCE = os.path.join(constants.SOURCES_PATH, constants.XMIPP_CORE)
+
 def test_returns_short_version():
 	command_words = ["xmipp3_installer", modes.MODE_VERSION, "--short"]
 	result = subprocess.run(command_words, capture_output=True, text=True)
@@ -47,17 +49,6 @@ def __delete_library_versions_file():
 		[os.path.dirname(constants.LIBRARY_VERSIONS_FILE)]
 	)
 
-def __delete_sources():
-	file_operations.delete_paths([
-		os.path.join(constants.SOURCES_PATH, source)
-		for source in constants.XMIPP_SOURCES
-	])
-
-def __make_source_directories():
-	for source in constants.XMIPP_SOURCES:
-		source_path = os.path.join(constants.SOURCES_PATH, source)
-		os.makedirs(source_path, exist_ok=True)
-
 @pytest.fixture(params=[False, False])
 def __setup_evironment(request):
 	lib_file_exist, sources_exist = request.param
@@ -70,10 +61,10 @@ def __setup_evironment(request):
 				constants.LIBRARY_VERSIONS_FILE
 			)
 		if not sources_exist:
-			__delete_sources()
+			file_operations.delete_paths([__CORE_SOURCE])
 		else:
-			__make_source_directories()
+			os.makedirs(__CORE_SOURCE, exist_ok=True)
 		yield lib_file_exist, sources_exist
 	finally:
 		__delete_library_versions_file()
-		__delete_sources()
+		file_operations.delete_paths([__CORE_SOURCE])

--- a/tests/e2e/mode_version_test.py
+++ b/tests/e2e/mode_version_test.py
@@ -3,7 +3,6 @@ import subprocess
 
 import pytest
 
-from xmipp3_installer.application.cli import arguments
 from xmipp3_installer.application.cli.arguments import modes
 from xmipp3_installer.installer import constants
 from xmipp3_installer.installer.tmp import versions

--- a/tests/e2e/shell_command_outputs/mode_version.py
+++ b/tests/e2e/shell_command_outputs/mode_version.py
@@ -32,15 +32,10 @@ Release date:            {versions.RELEASE_DATE}
 Compilation date:        -
 System version:          {installation_info_assembler.get_os_release_name()}"""
 
-__SOURCES_NOT_FOUND_SECTION = f"""xmippCore branch:        {__SOURCE_NOT_FOUND_MESSAGE}
-xmippViz branch:         {__SOURCE_NOT_FOUND_MESSAGE}"""
+__SOURCES_NOT_FOUND_SECTION = f"""xmippCore branch:        {__SOURCE_NOT_FOUND_MESSAGE}"""
 
 def get_sources_found_section():
-  found_source_message = __get_found_source_message()
-  return '\n'.join([
-    f"xmippCore branch:        {found_source_message}",
-    f"xmippViz branch:         {found_source_message}"
-  ])
+  return f"xmippCore branch:        {__get_found_source_message()}"
 
 def get_full_info_before_config():
   return '\n'.join([

--- a/tests/e2e/shell_command_outputs/mode_version.py
+++ b/tests/e2e/shell_command_outputs/mode_version.py
@@ -32,7 +32,7 @@ Release date:            {versions.RELEASE_DATE}
 Compilation date:        -
 System version:          {installation_info_assembler.get_os_release_name()}"""
 
-__SOURCES_NOT_FOUND_SECTION = f"""xmippCore branch:        {__SOURCE_NOT_FOUND_MESSAGE}"""
+__SOURCES_NOT_FOUND_SECTION = f"xmippCore branch:        {__SOURCE_NOT_FOUND_MESSAGE}"
 
 def get_sources_found_section():
   return f"xmippCore branch:        {__get_found_source_message()}"

--- a/tests/e2e/shell_command_outputs/mode_version.py
+++ b/tests/e2e/shell_command_outputs/mode_version.py
@@ -33,15 +33,13 @@ Compilation date:        -
 System version:          {installation_info_assembler.get_os_release_name()}"""
 
 __SOURCES_NOT_FOUND_SECTION = f"""xmippCore branch:        {__SOURCE_NOT_FOUND_MESSAGE}
-xmippViz branch:         {__SOURCE_NOT_FOUND_MESSAGE}
-scipion-em-xmipp branch: {__SOURCE_NOT_FOUND_MESSAGE}"""
+xmippViz branch:         {__SOURCE_NOT_FOUND_MESSAGE}"""
 
 def get_sources_found_section():
   found_source_message = __get_found_source_message()
   return '\n'.join([
     f"xmippCore branch:        {found_source_message}",
-    f"xmippViz branch:         {found_source_message}",
-    f"scipion-em-xmipp branch: {found_source_message}"
+    f"xmippViz branch:         {found_source_message}"
   ])
 
 def get_full_info_before_config():

--- a/tests/e2e/shell_command_outputs/mode_version.py
+++ b/tests/e2e/shell_command_outputs/mode_version.py
@@ -1,5 +1,6 @@
 from xmipp3_installer.api_client.assembler import installation_info_assembler
 from xmipp3_installer.application.logger.logger import logger
+from xmipp3_installer.installer import constants
 from xmipp3_installer.installer.tmp import versions
 from xmipp3_installer.installer.handlers import git_handler
 from xmipp3_installer.installer.modes.mode_version_executor import ModeVersionExecutor
@@ -9,7 +10,7 @@ def __get_found_source_message():
   source_message_line:str = version_executor._ModeVersionExecutor__get_source_info("")
   return source_message_line.replace("branch:", "").strip()
 
-__TITLE = f"Xmipp {versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY]} ({git_handler.get_current_branch()})"
+__TITLE = f"Xmipp {versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]} ({git_handler.get_current_branch()})"
 
 __SOURCE_NOT_FOUND_MESSAGE = logger.yellow("Not found")
 

--- a/tests/e2e/shell_command_outputs/mode_version.py
+++ b/tests/e2e/shell_command_outputs/mode_version.py
@@ -3,12 +3,6 @@ from xmipp3_installer.application.logger.logger import logger
 from xmipp3_installer.installer import constants
 from xmipp3_installer.installer.tmp import versions
 from xmipp3_installer.installer.handlers import git_handler
-from xmipp3_installer.installer.modes.mode_version_executor import ModeVersionExecutor
-
-def __get_found_source_message():
-  version_executor = ModeVersionExecutor({})
-  source_message_line:str = version_executor._ModeVersionExecutor__get_source_info("")
-  return source_message_line.replace("branch:", "").strip()
 
 __TITLE = f"Xmipp {versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]} ({git_handler.get_current_branch()})"
 
@@ -36,7 +30,7 @@ System version:          {installation_info_assembler.get_os_release_name()}"""
 __SOURCES_NOT_FOUND_SECTION = f"xmippCore branch:        {__SOURCE_NOT_FOUND_MESSAGE}"
 
 def get_sources_found_section():
-  return f"xmippCore branch:        {__get_found_source_message()}"
+  return f"xmippCore branch:        {git_handler.get_current_branch()} ({git_handler.get_current_commit()})"
 
 def get_full_info_before_config():
   return '\n'.join([

--- a/tests/unitary/api_client/assembler/installation_info_assembler_test.py
+++ b/tests/unitary/api_client/assembler/installation_info_assembler_test.py
@@ -106,7 +106,7 @@ __EMPTY_INSTALLATION_INFO = {
     "jpeg": None
   },
   "xmipp": {
-    "branch": versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY],
+    "branch": versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY],
     "updated": None,
     "installedByScipion": None
   },
@@ -370,9 +370,9 @@ def test_returns_expected_os_release_name(
 @pytest.mark.parametrize(
   "received_branch_name,expected_branch_name",
   [
-    pytest.param(None, versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY]),
-    pytest.param("", versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY]),
-    pytest.param(versions.MASTER_BRANCHNAME, versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY]),
+    pytest.param(None, versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]),
+    pytest.param("", versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]),
+    pytest.param(constants.MASTER_BRANCHNAME, versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]),
     pytest.param("devel", "devel")
   ]
 )

--- a/tests/unitary/application/logger/predefined_messages_test.py
+++ b/tests/unitary/application/logger/predefined_messages_test.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from xmipp3_installer.application.logger import predefined_messages
+from xmipp3_installer.installer import constants
 from xmipp3_installer.installer.tmp import versions
 
 from .... import get_assertion_message
@@ -168,6 +169,6 @@ def __mock_get_current_branch():
 @pytest.fixture(autouse=True)
 def __mock_xmipp_versions():
   with patch.object(versions, "XMIPP_VERSIONS", new={'key1': {'key2': __TAG_VERSION}}):
-    with patch.object(versions, "XMIPP", new="key1"):
+    with patch.object(constants, "XMIPP", new="key1"):
       with patch.object(versions, "VERSION_KEY", new="key2"):
         yield __TAG_VERSION

--- a/tests/unitary/installer/modes/mode_clean/mode_clean_all_executor_test.py
+++ b/tests/unitary/installer/modes/mode_clean/mode_clean_all_executor_test.py
@@ -69,13 +69,10 @@ def test_returns_expected_confirmation_message(
 def test_returns_expected_paths_to_delete(__mock_os_path_join):
 	paths = ModeCleanAllExecutor({})._get_paths_to_delete()
 	expected_paths = [
-		*[
-				__mock_os_path_join(constants.SOURCES_PATH, source)
-				for source in constants.XMIPP_SOURCES
-			],
-			constants.INSTALL_PATH,
-			constants.BUILD_PATH,
-			constants.CONFIG_FILE
+		__mock_os_path_join(constants.SOURCES_PATH, constants.XMIPP_CORE),
+		constants.INSTALL_PATH,
+		constants.BUILD_PATH,
+		constants.CONFIG_FILE
 	]
 	assert (
 		paths == expected_paths

--- a/tests/unitary/installer/modes/mode_clean/mode_clean_all_executor_test.py
+++ b/tests/unitary/installer/modes/mode_clean/mode_clean_all_executor_test.py
@@ -66,10 +66,10 @@ def test_returns_expected_confirmation_message(
 		confirmation_message == expected_confirmation_message
 	), get_assertion_message("confirmation message", expected_confirmation_message, confirmation_message)
 
-def test_returns_expected_paths_to_delete(__mock_os_path_join):
+def test_returns_expected_paths_to_delete():
 	paths = ModeCleanAllExecutor({})._get_paths_to_delete()
 	expected_paths = [
-		__mock_os_path_join(constants.SOURCES_PATH, constants.XMIPP_CORE),
+		constants.XMIPP_CORE_PATH,
 		constants.INSTALL_PATH,
 		constants.BUILD_PATH,
 		constants.CONFIG_FILE
@@ -103,13 +103,4 @@ def __mock_logger_yellow():
 		"xmipp3_installer.application.logger.logger.Logger.yellow"
 	) as mock_method:
 		mock_method.side_effect = lambda text: f"yellow-{text}-yellow"
-		yield mock_method
-
-@pytest.fixture(autouse=True)
-def __mock_os_path_join():
-	def __join_with_foward_slashes(*args):
-		args = [arg.rstrip("/") for arg in args]
-		return '/'.join([*args])
-	with patch("os.path.join") as mock_method:
-		mock_method.side_effect = __join_with_foward_slashes
 		yield mock_method

--- a/tests/unitary/installer/modes/mode_clean/mode_clean_bin_executor_test.py
+++ b/tests/unitary/installer/modes/mode_clean/mode_clean_bin_executor_test.py
@@ -97,7 +97,7 @@ def test_calls_os_walk_when_getting_empty_dirs(
 	__mock_os_walk.assert_called_once_with(
 		__mock_os_path_join(
 			constants.SOURCES_PATH,
-			versions.XMIPP,
+			constants.XMIPP,
 			"applications",
 			"programs"
 		)

--- a/tests/unitary/installer/modes/mode_clean/mode_clean_bin_executor_test.py
+++ b/tests/unitary/installer/modes/mode_clean/mode_clean_bin_executor_test.py
@@ -5,7 +5,6 @@ import pytest
 from xmipp3_installer.installer import constants
 from xmipp3_installer.installer.modes.mode_clean.mode_clean_bin_executor import ModeCleanBinExecutor
 from xmipp3_installer.installer.modes.mode_clean.mode_clean_executor import ModeCleanExecutor
-from xmipp3_installer.installer.tmp import versions
 
 from ..... import get_assertion_message
 

--- a/tests/unitary/installer/modes/mode_version_executor_test.py
+++ b/tests/unitary/installer/modes/mode_version_executor_test.py
@@ -318,7 +318,7 @@ def test_calls_logger_when_running_executor_in_short_format(__mock_logger):
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = True
 	version_executor.run()
-	__mock_logger.assert_called_once_with(versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERNAME_KEY])
+	__mock_logger.assert_called_once_with(versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERNAME_KEY])
 
 @pytest.mark.parametrize(
 	"__mock_are_all_sources_present,__mock_exists_library_versions,__mock_is_tag,expected_title_version_type",
@@ -355,7 +355,7 @@ def test_calls_logger_when_running_executor_in_long_format(
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = False
 	version_executor.run()
-	expected_title = f"Xmipp {versions.XMIPP_VERSIONS[versions.XMIPP][versions.VERSION_KEY]} ({expected_title_version_type})"
+	expected_title = f"Xmipp {versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]} ({expected_title_version_type})"
 	expected_calls = [
 		call(f"{logger.bold(expected_title)}\n"),
 		call(__mock_get_dates_section.return_value),

--- a/tests/unitary/installer/modes/mode_version_executor_test.py
+++ b/tests/unitary/installer/modes/mode_version_executor_test.py
@@ -298,17 +298,15 @@ def test_returns_expected_sources_info(__mock_get_source_info):
 	), get_assertion_message("sources info", expected_sources_info, sources_info)
 
 @pytest.mark.parametrize(
-	"__mock_exists_sources,expected_result",
+	"__mock_exists,expected_result",
 	[
-		pytest.param([False, False], False),
-		pytest.param([False, True], False),
-		pytest.param([True, False], False),
-		pytest.param([True, True], True)
+		pytest.param(False, False),
+		pytest.param(True, True)
 	],
-	indirect=["__mock_exists_sources"]
+	indirect=["__mock_exists"]
 )
 def test_returns_expected_value_when_checking_if_all_sources_are_present(
-	__mock_exists_sources,
+	__mock_exists,
 	expected_result
 ):
 	result = ModeVersionExecutor._ModeVersionExecutor__are_all_sources_present()
@@ -579,21 +577,6 @@ def __mock_exists_init(request, __mock_exists):
 			return config_file_exists
 		elif path == constants.LIBRARY_VERSIONS_FILE:
 			return lib_file_exists
-		else:
-			return False
-	_ = __side_effect("non-existent") # To cover system case
-	__mock_exists.side_effect = __side_effect
-	yield __mock_exists
-
-@pytest.fixture(params=[[True, True]])
-def __mock_exists_sources(request, __mock_exists):
-	def __side_effect(path):
-		core_exists = request.param[0]
-		viz_exists = request.param[1]
-		if path == os.path.join(constants.SOURCES_PATH, constants.XMIPP_CORE):
-			return core_exists
-		elif path == os.path.join(constants.SOURCES_PATH, constants.XMIPP_VIZ):
-			return viz_exists
 		else:
 			return False
 	_ = __side_effect("non-existent") # To cover system case

--- a/tests/unitary/installer/modes/mode_version_executor_test.py
+++ b/tests/unitary/installer/modes/mode_version_executor_test.py
@@ -319,23 +319,21 @@ def test_calls_logger_when_running_executor_in_long_format(
 	version_executor.short = False
 	version_executor.run()
 	expected_title = f"Xmipp {versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]} ({expected_title_version_type})"
-	expected_calls = [
-		call(f"{logger.bold(expected_title)}\n"),
-		call(__mock_get_dates_section()),
-		call(f"{__mock_add_padding_spaces('System version: ')}{__mock_get_os_release_name()}"),
-		call(__mock_get_xmipp_core_info())
+
+	expected_lines = [
+		f"{logger.bold(expected_title)}\n",
+		__mock_get_dates_section(),
+		f"{__mock_add_padding_spaces('System version: ')}{__mock_get_os_release_name()}",
+		__mock_get_xmipp_core_info()
 	]
 	if __mock_exist_sources_and_library_versions(constants.LIBRARY_VERSIONS_FILE):
-		expected_calls.append(call(f"\n{__mock_get_library_versions_section()}"))
+		expected_lines.append(f"\n{__mock_get_library_versions_section()}")
 	if (
 		not __mock_exist_sources_and_library_versions(constants.LIBRARY_VERSIONS_FILE) or
 		not __mock_exist_sources_and_library_versions(constants.XMIPP_CORE_PATH)
 	):
-		expected_calls.append(call(f"\n{__mock_get_configuration_warning_message()}"))
-	__mock_logger.assert_has_calls(expected_calls)
-	assert (
-		__mock_logger.call_count == len(expected_calls)
-	), get_assertion_message("number of logger calls", len(expected_calls), __mock_logger.call_count)
+		expected_lines.append(f"\n{__mock_get_configuration_warning_message()}")
+	__mock_logger.assert_called_once_with('\n'.join(expected_lines))
 
 def test_calls_is_tag_when_running_executor_in_long_format(
 	__mock_logger,

--- a/tests/unitary/installer/modes/mode_version_executor_test.py
+++ b/tests/unitary/installer/modes/mode_version_executor_test.py
@@ -300,14 +300,10 @@ def test_returns_expected_sources_info(__mock_get_source_info):
 @pytest.mark.parametrize(
 	"__mock_exists_sources,expected_result",
 	[
-		pytest.param([False, False, False], False),
-		pytest.param([False, False, True], False),
-		pytest.param([False, True, False], False),
-		pytest.param([False, True, True], False),
-		pytest.param([True, False, False], False),
-		pytest.param([True, False, True], False),
-		pytest.param([True, True, False], False),
-		pytest.param([True, True, True], True)
+		pytest.param([False, False], False),
+		pytest.param([False, True], False),
+		pytest.param([True, False], False),
+		pytest.param([True, True], True)
 	],
 	indirect=["__mock_exists_sources"]
 )
@@ -589,18 +585,15 @@ def __mock_exists_init(request, __mock_exists):
 	__mock_exists.side_effect = __side_effect
 	yield __mock_exists
 
-@pytest.fixture(params=[[True, True, True]])
+@pytest.fixture(params=[[True, True]])
 def __mock_exists_sources(request, __mock_exists):
 	def __side_effect(path):
 		core_exists = request.param[0]
 		viz_exists = request.param[1]
-		plugin_exists = request.param[2]
 		if path == os.path.join(constants.SOURCES_PATH, constants.XMIPP_CORE):
 			return core_exists
 		elif path == os.path.join(constants.SOURCES_PATH, constants.XMIPP_VIZ):
 			return viz_exists
-		elif path == os.path.join(constants.SOURCES_PATH, constants.XMIPP_PLUGIN):
-			return plugin_exists
 		else:
 			return False
 	_ = __side_effect("non-existent") # To cover system case

--- a/tests/unitary/installer/modes/mode_version_executor_test.py
+++ b/tests/unitary/installer/modes/mode_version_executor_test.py
@@ -17,10 +17,9 @@ __LEFT_TEXT_LEN = 5
 __DATE = "dd/mm/yyyy"
 __FIXED_DATES_SECTION_PART = f"""Release date: {versions.RELEASE_DATE}
 Compilation date: """
-__SOURCE = "xmipp-dependency"
-__SOURCE_PATH = os.path.join(constants.SOURCES_PATH, __SOURCE)
+__SOURCE = constants.XMIPP_CORE
 __COMMIT = "5c3a24f"
-__SOURCE_LEFT_TEXT = f"{__SOURCE} branch: "
+__XMIPP_CORE_LEFT_TEXT = f"{__SOURCE} branch: "
 __TAG_NAME = "tags/v3.24.06-Oceanus"
 __BRANCH_NAME = "devel"
 __RELEASE_NAME = "Ubuntu 24.04"
@@ -200,8 +199,8 @@ def test_calls_add_padding_spaces_when_getting_source_info(
 ):
 	__mock_exists.return_value = False
 	version_executor = ModeVersionExecutor({})
-	version_executor._ModeVersionExecutor__get_source_info(__SOURCE)
-	__mock_add_padding_spaces.assert_called_once_with(__SOURCE_LEFT_TEXT)
+	version_executor._ModeVersionExecutor__get_xmipp_core_info()
+	__mock_add_padding_spaces.assert_called_once_with(__XMIPP_CORE_LEFT_TEXT)
 
 def test_calls_get_current_commit_when_getting_source_info(
 	__mock_add_padding_spaces,
@@ -212,8 +211,8 @@ def test_calls_get_current_commit_when_getting_source_info(
 	__mock_is_tag
 ):
 	version_executor = ModeVersionExecutor({})
-	version_executor._ModeVersionExecutor__get_source_info(__SOURCE)
-	__mock_get_current_commit.assert_called_once_with(dir=__SOURCE_PATH)
+	version_executor._ModeVersionExecutor__get_xmipp_core_info()
+	__mock_get_current_commit.assert_called_once_with(dir=constants.XMIPP_CORE_PATH)
 
 def test_calls_get_commit_branch_when_getting_source_info(
 	__mock_add_padding_spaces,
@@ -224,10 +223,10 @@ def test_calls_get_commit_branch_when_getting_source_info(
 	__mock_is_tag
 ):
 	version_executor = ModeVersionExecutor({})
-	version_executor._ModeVersionExecutor__get_source_info(__SOURCE)
+	version_executor._ModeVersionExecutor__get_xmipp_core_info()
 	__mock_get_commit_branch.assert_called_once_with(
 		__mock_get_current_commit.return_value,
-		dir=__SOURCE_PATH
+		dir=constants.XMIPP_CORE_PATH
 	)
 
 def test_calls_get_current_branch_when_getting_source_info(
@@ -239,8 +238,8 @@ def test_calls_get_current_branch_when_getting_source_info(
 	__mock_is_tag
 ):
 	version_executor = ModeVersionExecutor({})
-	version_executor._ModeVersionExecutor__get_source_info(__SOURCE)
-	__mock_get_current_branch.assert_called_once_with(dir=__SOURCE_PATH)
+	version_executor._ModeVersionExecutor__get_xmipp_core_info()
+	__mock_get_current_branch.assert_called_once_with(dir=constants.XMIPP_CORE_PATH)
 
 def test_calls_is_tag_when_getting_source_info(
 	__mock_add_padding_spaces,
@@ -251,8 +250,8 @@ def test_calls_is_tag_when_getting_source_info(
 	__mock_is_tag
 ):
 	version_executor = ModeVersionExecutor({})
-	version_executor._ModeVersionExecutor__get_source_info(__SOURCE)
-	__mock_is_tag.assert_called_once_with(dir=__SOURCE_PATH)
+	version_executor._ModeVersionExecutor__get_xmipp_core_info()
+	__mock_is_tag.assert_called_once_with(dir=constants.XMIPP_CORE_PATH)
 
 @pytest.mark.parametrize(
 	"__mock_exists,__mock_is_tag,expected_info_right",
@@ -274,28 +273,11 @@ def test_returns_expected_source_info(
 	__mock_is_tag
 ):
 	version_executor = ModeVersionExecutor({})
-	source_info = version_executor._ModeVersionExecutor__get_source_info(__SOURCE)
-	expected_info = f"{__SOURCE_LEFT_TEXT}{expected_info_right}"
+	source_info = version_executor._ModeVersionExecutor__get_xmipp_core_info()
+	expected_info = f"{__XMIPP_CORE_LEFT_TEXT}{expected_info_right}"
 	assert (
 		source_info == expected_info
 	), get_assertion_message("source info", expected_info, source_info)
-
-def test_calls_get_source_info_when_getting_sources_info(__mock_get_source_info):
-	version_executor = ModeVersionExecutor({})
-	version_executor._ModeVersionExecutor__get_sources_info()
-	__mock_get_source_info.assert_has_calls([
-		call(source) for source in constants.XMIPP_SOURCES
-	])
-
-def test_returns_expected_sources_info(__mock_get_source_info):
-	version_executor = ModeVersionExecutor({})
-	sources_info = version_executor._ModeVersionExecutor__get_sources_info()
-	expected_sources_info = '\n'.join([
-		__mock_get_source_info(source) for source in constants.XMIPP_SOURCES
-	])
-	assert (
-		sources_info == expected_sources_info
-	), get_assertion_message("sources info", expected_sources_info, sources_info)
 
 def test_calls_logger_when_running_executor_in_short_format(__mock_logger):
 	version_executor = ModeVersionExecutor({})
@@ -328,7 +310,7 @@ def test_calls_logger_when_running_executor_in_long_format(
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info,
+	__mock_get_xmipp_core_info,
 	__mock_get_library_versions_section,
 	__mock_exist_sources_and_library_versions,
 	__mock_get_configuration_warning_message
@@ -339,17 +321,17 @@ def test_calls_logger_when_running_executor_in_long_format(
 	expected_title = f"Xmipp {versions.XMIPP_VERSIONS[constants.XMIPP][versions.VERSION_KEY]} ({expected_title_version_type})"
 	expected_calls = [
 		call(f"{logger.bold(expected_title)}\n"),
-		call(__mock_get_dates_section.return_value),
-		call(f"{__mock_add_padding_spaces('System version: ')}{__mock_get_os_release_name.return_value}"),
-		call(__mock_get_sources_info.return_value),
+		call(__mock_get_dates_section()),
+		call(f"{__mock_add_padding_spaces('System version: ')}{__mock_get_os_release_name()}"),
+		call(__mock_get_xmipp_core_info())
 	]
 	if __mock_exist_sources_and_library_versions(constants.LIBRARY_VERSIONS_FILE):
-		expected_calls.append(call(f"\n{__mock_get_library_versions_section.return_value}"))
+		expected_calls.append(call(f"\n{__mock_get_library_versions_section()}"))
 	if (
 		not __mock_exist_sources_and_library_versions(constants.LIBRARY_VERSIONS_FILE) or
 		not __mock_exist_sources_and_library_versions(constants.XMIPP_CORE_PATH)
 	):
-		expected_calls.append(call(f"\n{__mock_get_configuration_warning_message.return_value}"))
+		expected_calls.append(call(f"\n{__mock_get_configuration_warning_message()}"))
 	__mock_logger.assert_has_calls(expected_calls)
 	assert (
 		__mock_logger.call_count == len(expected_calls)
@@ -362,7 +344,7 @@ def test_calls_is_tag_when_running_executor_in_long_format(
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info
+	__mock_get_xmipp_core_info
 ):
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = False
@@ -376,7 +358,7 @@ def test_calls_get_current_branch_when_running_executor_in_long_format_and_is_no
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info
+	__mock_get_xmipp_core_info
 ):
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = False
@@ -390,7 +372,7 @@ def test_does_not_call_get_current_branch_when_running_executor_in_long_format_a
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info
+	__mock_get_xmipp_core_info
 ):
 	__mock_is_tag.return_value = True
 	version_executor = ModeVersionExecutor({})
@@ -405,7 +387,7 @@ def test_calls_get_dates_section_when_running_executor_in_long_format(
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info
+	__mock_get_xmipp_core_info
 ):
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = False
@@ -419,7 +401,7 @@ def test_calls_add_padding_spaces_when_running_executor_in_long_format(
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info
+	__mock_get_xmipp_core_info
 ):
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = False
@@ -433,7 +415,7 @@ def test_calls_get_os_release_name_when_running_executor_in_long_format(
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info
+	__mock_get_xmipp_core_info
 ):
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = False
@@ -447,12 +429,12 @@ def test_calls_get_sources_info_when_running_executor_in_long_format(
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info
+	__mock_get_xmipp_core_info
 ):
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = False
 	version_executor.run()
-	__mock_get_sources_info.assert_called_once_with()
+	__mock_get_xmipp_core_info.assert_called_once_with()
 
 @pytest.mark.parametrize(
 	"short_format",
@@ -469,7 +451,7 @@ def test_returns_success_and_no_message_when_running_executor(
 	__mock_get_dates_section,
 	__mock_add_padding_spaces,
 	__mock_get_os_release_name,
-	__mock_get_sources_info
+	__mock_get_xmipp_core_info
 ):
 	version_executor = ModeVersionExecutor({})
 	version_executor.short = short_format
@@ -664,11 +646,11 @@ def __mock_is_tag(request):
 		yield mock_method
 
 @pytest.fixture
-def __mock_get_source_info():
+def __mock_get_xmipp_core_info():
 	with patch(
-		"xmipp3_installer.installer.modes.mode_version_executor.ModeVersionExecutor._ModeVersionExecutor__get_source_info"
+		"xmipp3_installer.installer.modes.mode_version_executor.ModeVersionExecutor._ModeVersionExecutor__get_xmipp_core_info"
 	) as mock_method:
-		mock_method.side_effect = lambda source: f"{source} info"
+		mock_method.return_value = "xmipp core info"
 		yield mock_method
 
 @pytest.fixture
@@ -692,14 +674,6 @@ def __mock_get_os_release_name():
 		"xmipp3_installer.api_client.assembler.installation_info_assembler.get_os_release_name"
 	) as mock_method:
 		mock_method.return_value = __RELEASE_NAME
-		yield mock_method
-
-@pytest.fixture
-def __mock_get_sources_info():
-	with patch(
-		"xmipp3_installer.installer.modes.mode_version_executor.ModeVersionExecutor._ModeVersionExecutor__get_sources_info"
-	) as mock_method:
-		mock_method.return_value = "Source1: info\nSource2: info\n"
 		yield mock_method
 
 @pytest.fixture


### PR DESCRIPTION
As part of the new installation system, Xmipp will from now on only handle xmippCore as a dependency, because scipion-em-xmipp and xmippViz are not really dependencies of Xmipp, so it should not nothing about them.

xmippViz will from now on be handled by scipion-em-xmipp (which will also handle itself).