### PR TITLE
Properly check override params in tests

### DIFF
--- a/src/xmipp3_installer/installer/modes/mode_get_sources_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_get_sources_executor.py
@@ -39,6 +39,13 @@ class ModeGetSourcesExecutor(mode_executor.ModeExecutor):
 				return errors.SOURCE_CLONE_ERROR, output
 		return 0, ""
 	
+	def _set_executor_config(self):
+		"""
+		### Sets the specific executor params for this mode.
+		"""
+		super()._set_executor_config()
+		self.prints_with_substitution = True
+	
 	def __select_ref_to_clone(self, source_name: str, source_repo: str) -> str:
 		"""
 		### Selects the reference to clone from the source.

--- a/tests/unitary/installer/modes/mode_config_executor_test.py
+++ b/tests/unitary/installer/modes/mode_config_executor_test.py
@@ -59,12 +59,14 @@ def test_does_not_override_parent_config_values(__dummy_test_mode_executor):
 	base_config = (
 		base_executor.logs_to_file,
 		base_executor.prints_with_substitution,
-		base_executor.prints_banner_on_exit
+		base_executor.prints_banner_on_exit,
+		base_executor.sends_installation_info
 	)
 	inherited_config = (
 		config_executor.logs_to_file,
 		config_executor.prints_with_substitution,
-		config_executor.prints_banner_on_exit
+		config_executor.prints_banner_on_exit,
+		config_executor.sends_installation_info
 	)
 	assert (
 		inherited_config == base_config

--- a/tests/unitary/installer/modes/mode_get_sources_executor_test.py
+++ b/tests/unitary/installer/modes/mode_get_sources_executor_test.py
@@ -46,6 +46,26 @@ def test_implements_interface_mode_executor():
 		executor.__class__.__bases__[0].__name__
 	)
 
+def test_overrides_expected_parent_config_values(__dummy_test_mode_executor):
+	base_executor = __dummy_test_mode_executor(__CONTEXT.copy())
+	base_executor.run()  # To cover dummy implementation execution
+	config_executor = ModeGetSourcesExecutor(__CONTEXT.copy())
+	base_config = (
+		base_executor.logs_to_file,
+		not base_executor.prints_with_substitution,
+		base_executor.prints_banner_on_exit,
+		base_executor.sends_installation_info
+	)
+	inherited_config = (
+		config_executor.logs_to_file,
+		config_executor.prints_with_substitution,
+		config_executor.prints_banner_on_exit,
+		config_executor.sends_installation_info
+	)
+	assert (
+		inherited_config == base_config
+	), get_assertion_message("config values", base_config, inherited_config)
+
 def test_stores_expected_values_when_initializing():
 	executor = ModeGetSourcesExecutor(__CONTEXT.copy())
 	values = (
@@ -428,6 +448,13 @@ def test_returns_expected_result_when_running_executor(
 	assert (
 		result == expected_result
 	), get_assertion_message("executor result", expected_result, result)
+
+@pytest.fixture
+def __dummy_test_mode_executor():
+	class TestExecutor(ModeExecutor):
+		def run(self):
+			return (0, "")
+	return TestExecutor
 
 @pytest.fixture(params=[__BRANCH_NAME])
 def __mock_get_current_branch(request):

--- a/tests/unitary/installer/modes/mode_git_executor_test.py
+++ b/tests/unitary/installer/modes/mode_git_executor_test.py
@@ -41,12 +41,14 @@ def test_does_not_override_parent_config_values(
 	base_config = (
 		base_executor.logs_to_file,
 		base_executor.prints_with_substitution,
-		base_executor.prints_banner_on_exit
+		base_executor.prints_banner_on_exit,
+		base_executor.sends_installation_info
 	)
 	inherited_config = (
 		git_executor.logs_to_file,
 		git_executor.prints_with_substitution,
-		git_executor.prints_banner_on_exit
+		git_executor.prints_banner_on_exit,
+		git_executor.sends_installation_info
 	)
 	assert (
 		inherited_config == base_config

--- a/tests/unitary/installer/modes/mode_sync/mode_sync_executor_test.py
+++ b/tests/unitary/installer/modes/mode_sync/mode_sync_executor_test.py
@@ -39,16 +39,18 @@ def test_does_not_override_parent_config_values(
 ):
 	base_executor = __dummy_test_mode_executor({})
 	base_executor.run() # To cover dummy implementation execution
-	models_executor = DummySyncExecutor({})
+	mode_sync_executor = DummySyncExecutor({})
 	base_config = (
 		base_executor.logs_to_file,
 		base_executor.prints_with_substitution,
-		base_executor.prints_banner_on_exit
+		base_executor.prints_banner_on_exit,
+		base_executor.sends_installation_info
 	)
 	inherited_config = (
-		models_executor.logs_to_file,
-		models_executor.prints_with_substitution,
-		models_executor.prints_banner_on_exit
+		mode_sync_executor.logs_to_file,
+		mode_sync_executor.prints_with_substitution,
+		mode_sync_executor.prints_banner_on_exit,
+		mode_sync_executor.sends_installation_info
 	)
 	assert (
 		inherited_config == base_config

--- a/tests/unitary/installer/modes/mode_version_executor_test.py
+++ b/tests/unitary/installer/modes/mode_version_executor_test.py
@@ -131,16 +131,18 @@ def test_sets_version_values_as_expected_when_initializing():
 def test_does_not_override_parent_config_values(__dummy_test_mode_executor):
 	base_executor = __dummy_test_mode_executor(__CONTEXT.copy())
 	base_executor.run()  # To cover dummy implementation execution
-	config_executor = ModeVersionExecutor(__CONTEXT.copy())
+	version_executor = ModeVersionExecutor(__CONTEXT.copy())
 	base_config = (
 		base_executor.logs_to_file,
 		base_executor.prints_with_substitution,
-		base_executor.prints_banner_on_exit
+		base_executor.prints_banner_on_exit,
+		base_executor.sends_installation_info
 	)
 	inherited_config = (
-		config_executor.logs_to_file,
-		config_executor.prints_with_substitution,
-		config_executor.prints_banner_on_exit
+		version_executor.logs_to_file,
+		version_executor.prints_with_substitution,
+		version_executor.prints_banner_on_exit,
+		version_executor.sends_installation_info
 	)
 	assert (
 		inherited_config == base_config


### PR DESCRIPTION
Also, for mode `getSources`: Make sure it overrides print with substitution.