### PR TITLE
Get sources warning fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xmipp3_installer"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   { name = "Martín Salinas", email = "ssalinasmartin@gmail.com" },
 ]

--- a/src/xmipp3_installer/installer/modes/mode_get_sources_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_get_sources_executor.py
@@ -120,10 +120,10 @@ class ModeGetSourcesExecutor(mode_executor.ModeExecutor):
 
 		clone_branch = self.__select_ref_to_clone(source_name, repo_url)
 		if self.target_branch and not clone_branch:
-			warning_message = logger.yellow("\n".join([
-				f"Warning: branch \'{self.target_branch}\' does not exist for repository with url {repo_url}.",
-				"Falling back to repository's default branch."
-			]))
+			warning_message = "\n".join([
+				logger.yellow(f"Warning: branch \'{self.target_branch}\' does not exist for repository with url {repo_url}"),
+				logger.yellow("Falling back to repository's default branch.")
+			])
 			logger(warning_message, substitute=self.substitute)
 		
 		ret_code, output = self.__run_source_command(source_name, repo_url, clone_branch)

--- a/tests/e2e/shell_command_outputs/mode_get_sources.py
+++ b/tests/e2e/shell_command_outputs/mode_get_sources.py
@@ -11,10 +11,10 @@ __CLONING_XMIPP_VIZ = f"Cloning {constants.XMIPP_VIZ}..."
 
 BRANCH_NAME = "branch_name"
 def __get_branch_not_found_warning(source_name: str) -> str:
-  return logger.yellow("\n".join([
-    f"Warning: branch \'{BRANCH_NAME}\' does not exist for repository with url https://github.com/i2pc/{source_name}.",
-    "Falling back to repository's default branch."
-  ]))
+  return "\n".join([
+    logger.yellow(f"Warning: branch \'{BRANCH_NAME}\' does not exist for repository with url https://github.com/i2pc/{source_name}"),
+    logger.yellow("Falling back to repository's default branch.")
+  ])
 
 GIT_COMMAND_FAILURE_MESSAGE = "failure message"
 __FAILURE_COMPLETE_MESSAGE = logger.red(f"""{GIT_COMMAND_FAILURE_MESSAGE}

--- a/tests/unitary/installer/modes/mode_get_sources_executor_test.py
+++ b/tests/unitary/installer/modes/mode_get_sources_executor_test.py
@@ -311,10 +311,11 @@ def test_calls_logger_when_getting_source(
 	]
 	if target_branch and not __mock_select_ref_to_clone():
 		expected_calls.append(
-			call(__mock_logger_yellow(
-					f"Warning: branch \'{target_branch}\' does not exist for repository with url {__mock_i2pc_repo_url}{source_name}.\n"
-					"Falling back to repository's default branch."
-				),
+			call(
+				"\n".join([
+					__mock_logger_yellow(f"Warning: branch \'{target_branch}\' does not exist for repository with url {__mock_i2pc_repo_url}{source_name}"),
+					__mock_logger_yellow("Falling back to repository's default branch.")
+				]),
 				substitute=substitute
 			)
 		)


### PR DESCRIPTION
Mode `getSources` was not properly displaying "branch not found" warning message. The second line of the message was not being colored to yellow, and adding a point at the end of the sentence right after a url caused the point to be included in the url and therefore lead to a 404 error if followed.