### PR TITLE
Two new flags for mode `test`: `--all-functions` & `--all-programs`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@main
-
-    - name: Set up Python
-      uses: actions/setup-python@main
-      with:
-        python-version: '3.12'
     
     - name: Install dependencies
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xmipp3_installer"
-version = "1.0.2"
+version = "1.1.0"
 authors = [
   { name = "Martín Salinas", email = "ssalinasmartin@gmail.com" },
 ]

--- a/src/xmipp3_installer/application/cli/arguments/modes.py
+++ b/src/xmipp3_installer/application/cli/arguments/modes.py
@@ -7,7 +7,6 @@ from xmipp3_installer.application.cli.arguments.params import (
   PARAM_LOGIN, PARAM_MODEL_PATH, PARAM_UPDATE, PARAMS, PARAM_ALL_FUNCTIONS,
   PARAM_ALL_PROGRAMS, SHORT_VERSION, LONG_VERSION
 )
-from xmipp3_installer.application.logger.logger import logger
 from xmipp3_installer.installer import urls
 
 MODE = "mode"
@@ -54,8 +53,7 @@ MODES = {
       f'If used with \'{PARAMS[PARAM_TEST_NAMES][SHORT_VERSION]}\', only the tests provided will run.',
       f'If used with \'{PARAMS[PARAM_SHOW_TESTS][LONG_VERSION]}\', a list the tests available and how to invoke them will be shown.',
       f'If used with \'{PARAMS[PARAM_ALL_FUNCTIONS][LONG_VERSION]}\', all function tests will run.',
-      f'If used with \'{PARAMS[PARAM_ALL_PROGRAMS][LONG_VERSION]}\', all program tests will run.',
-      logger.yellow('Important: Params in this mode are mutually exclusive. Only one can be used at a time.')
+      f'If used with \'{PARAMS[PARAM_ALL_PROGRAMS][LONG_VERSION]}\', all program tests will run.'
     ]
   },
   'Developers': {
@@ -83,6 +81,9 @@ MODES = {
 }
 
 # Arguments of each mode, sorted by group
+# Inside each mode, params are grouped by mutually exclusive groups
+# For example: MYMODE: [[PARAM1, PARAM2], [PARAM3, PARAM4]] would translate to
+# "mymode ([param1] [param2] | [param3] [param4])" in the general help message
 MODE_ARGS = {
   MODE_VERSION: [PARAM_SHORT],
   MODE_COMPILE_AND_INSTALL: [PARAM_JOBS, PARAM_KEEP_OUTPUT],
@@ -93,7 +94,7 @@ MODE_ARGS = {
   MODE_GET_SOURCES: [PARAM_BRANCH, PARAM_KEEP_OUTPUT],
   MODE_CLEAN_BIN: [],
   MODE_CLEAN_ALL: [],
-  MODE_TEST: [PARAM_TEST_NAMES, PARAM_SHOW_TESTS, PARAM_ALL_FUNCTIONS, PARAM_ALL_PROGRAMS],
+  MODE_TEST: [[PARAM_TEST_NAMES], [PARAM_SHOW_TESTS], [PARAM_ALL_FUNCTIONS], [PARAM_ALL_PROGRAMS]],
   MODE_GIT: [PARAM_GIT_COMMAND],
   MODE_ADD_MODEL: [PARAM_LOGIN, PARAM_MODEL_PATH, PARAM_UPDATE]
 }

--- a/src/xmipp3_installer/application/cli/arguments/modes.py
+++ b/src/xmipp3_installer/application/cli/arguments/modes.py
@@ -4,8 +4,10 @@ from xmipp3_installer.application.cli import arguments
 from xmipp3_installer.application.cli.arguments.params import (
   PARAM_SHORT, PARAM_JOBS, PARAM_BRANCH, PARAM_KEEP_OUTPUT, PARAM_OVERWRITE,
   PARAM_MODELS_DIRECTORY, PARAM_TEST_NAMES, PARAM_SHOW_TESTS, PARAM_GIT_COMMAND,
-  PARAM_LOGIN, PARAM_MODEL_PATH, PARAM_UPDATE, PARAMS, SHORT_VERSION, LONG_VERSION
+  PARAM_LOGIN, PARAM_MODEL_PATH, PARAM_UPDATE, PARAMS, PARAM_ALL_FUNCTIONS,
+  PARAM_ALL_PROGRAMS, SHORT_VERSION, LONG_VERSION
 )
+from xmipp3_installer.application.logger.logger import logger
 from xmipp3_installer.installer import urls
 
 MODE = "mode"
@@ -47,7 +49,14 @@ MODES = {
     MODE_CLEAN_ALL: ['Removes all compiled binaries and sources, leaves the repository as if freshly cloned (without pulling).']
   },
   'Test': {
-    MODE_TEST: ['Runs a given test.']
+    MODE_TEST: [
+      'Runs Xmipp\'s tests.',
+      f'If used with \'{PARAMS[PARAM_TEST_NAMES][SHORT_VERSION]}\', only the tests provided will run.',
+      f'If used with \'{PARAMS[PARAM_SHOW_TESTS][LONG_VERSION]}\', a list the tests available and how to invoke them will be shown.',
+      f'If used with \'{PARAMS[PARAM_ALL_FUNCTIONS][LONG_VERSION]}\', all function tests will run.',
+      f'If used with \'{PARAMS[PARAM_ALL_PROGRAMS][LONG_VERSION]}\', all program tests will run.',
+      logger.yellow(f'Important: Params in this mode are mutually exclusive. Only one can be used at a time.')
+    ]
   },
   'Developers': {
     MODE_GIT: ['Runs the given git action for all source repositories.'],
@@ -84,7 +93,7 @@ MODE_ARGS = {
   MODE_GET_SOURCES: [PARAM_BRANCH, PARAM_KEEP_OUTPUT],
   MODE_CLEAN_BIN: [],
   MODE_CLEAN_ALL: [],
-  MODE_TEST: [PARAM_TEST_NAMES, PARAM_SHOW_TESTS],
+  MODE_TEST: [PARAM_TEST_NAMES, PARAM_SHOW_TESTS, PARAM_ALL_FUNCTIONS, PARAM_ALL_PROGRAMS],
   MODE_GIT: [PARAM_GIT_COMMAND],
   MODE_ADD_MODEL: [PARAM_LOGIN, PARAM_MODEL_PATH, PARAM_UPDATE]
 }
@@ -123,7 +132,9 @@ MODE_EXAMPLES = {
   MODE_CLEAN_ALL: [],
   MODE_TEST: [
     f'./xmipp {MODE_TEST} xmipp_sample_test',
-    f'./xmipp {MODE_TEST} {PARAMS[PARAM_SHORT][LONG_VERSION]}',
+    f'./xmipp {MODE_TEST} {PARAMS[PARAM_SHOW_TESTS][LONG_VERSION]}',
+    f'./xmipp {MODE_TEST} {PARAMS[PARAM_ALL_FUNCTIONS][LONG_VERSION]}',
+    f'./xmipp {MODE_TEST} {PARAMS[PARAM_ALL_PROGRAMS][LONG_VERSION]}'
   ],
   MODE_GIT: [
     f'./xmipp {MODE_GIT} pull',

--- a/src/xmipp3_installer/application/cli/arguments/modes.py
+++ b/src/xmipp3_installer/application/cli/arguments/modes.py
@@ -55,7 +55,7 @@ MODES = {
       f'If used with \'{PARAMS[PARAM_SHOW_TESTS][LONG_VERSION]}\', a list the tests available and how to invoke them will be shown.',
       f'If used with \'{PARAMS[PARAM_ALL_FUNCTIONS][LONG_VERSION]}\', all function tests will run.',
       f'If used with \'{PARAMS[PARAM_ALL_PROGRAMS][LONG_VERSION]}\', all program tests will run.',
-      logger.yellow(f'Important: Params in this mode are mutually exclusive. Only one can be used at a time.')
+      logger.yellow('Important: Params in this mode are mutually exclusive. Only one can be used at a time.')
     ]
   },
   'Developers': {

--- a/src/xmipp3_installer/application/cli/arguments/params.py
+++ b/src/xmipp3_installer/application/cli/arguments/params.py
@@ -14,6 +14,8 @@ PARAM_BRANCH = 'branch'
 PARAM_MODELS_DIRECTORY = 'directory'
 PARAM_TEST_NAMES = 'testNames'
 PARAM_SHOW_TESTS = 'show'
+PARAM_ALL_FUNCTIONS = 'all_functions'
+PARAM_ALL_PROGRAMS = 'all_programs'
 PARAM_GIT_COMMAND = 'command'
 PARAM_LOGIN = 'login'
 PARAM_MODEL_PATH = 'modelPath'
@@ -42,11 +44,19 @@ PARAMS = {
   },
   PARAM_TEST_NAMES: {
     SHORT_VERSION: PARAM_TEST_NAMES,
-    DESCRIPTION: "Name of the tests to run. If combined with --show, greps the test names from the test list."
+    DESCRIPTION: "Name of the tests to run."
   },
   PARAM_SHOW_TESTS: {
     LONG_VERSION: "--show",
     DESCRIPTION: "Shows the tests available and how to invoke those."
+  },
+  PARAM_ALL_FUNCTIONS : {
+    LONG_VERSION: "--all-functions",
+    DESCRIPTION: "If set, all function tests will be run."
+  },
+  PARAM_ALL_PROGRAMS : {
+    LONG_VERSION: "--all-programs",
+    DESCRIPTION: "If set, all program tests will be run."
   },
   PARAM_GIT_COMMAND: {
     SHORT_VERSION: PARAM_GIT_COMMAND,

--- a/src/xmipp3_installer/application/cli/cli.py
+++ b/src/xmipp3_installer/application/cli/cli.py
@@ -178,8 +178,11 @@ def __add_params_mode_test(subparser: argparse.ArgumentParser):
   #### Params:
   - subparser (ArgumentParser): Subparser to add the params to.
   """
-  subparser.add_argument(*format.get_param_names(params.PARAM_TEST_NAMES), nargs='*', default=None)
-  subparser.add_argument(*format.get_param_names(params.PARAM_SHOW_TESTS), action='store_true')
+  group = subparser.add_mutually_exclusive_group(required=True)
+  group.add_argument(*format.get_param_names(params.PARAM_TEST_NAMES), nargs='*', default=None)
+  group.add_argument(*format.get_param_names(params.PARAM_SHOW_TESTS), action='store_true')
+  group.add_argument(*format.get_param_names(params.PARAM_ALL_FUNCTIONS), action='store_true')
+  group.add_argument(*format.get_param_names(params.PARAM_ALL_PROGRAMS), action='store_true')
 
 def __add_params_mode_version(subparser: argparse.ArgumentParser):
   """

--- a/src/xmipp3_installer/application/cli/cli.py
+++ b/src/xmipp3_installer/application/cli/cli.py
@@ -179,7 +179,7 @@ def __add_params_mode_test(subparser: argparse.ArgumentParser):
   - subparser (ArgumentParser): Subparser to add the params to.
   """
   group = subparser.add_mutually_exclusive_group(required=True)
-  group.add_argument(*format.get_param_names(params.PARAM_TEST_NAMES), nargs='*', default=None)
+  group.add_argument(*format.get_param_names(params.PARAM_TEST_NAMES), nargs='*', default=[])
   group.add_argument(*format.get_param_names(params.PARAM_SHOW_TESTS), action='store_true')
   group.add_argument(*format.get_param_names(params.PARAM_ALL_FUNCTIONS), action='store_true')
   group.add_argument(*format.get_param_names(params.PARAM_ALL_PROGRAMS), action='store_true')

--- a/src/xmipp3_installer/application/cli/parsers/base_help_formatter.py
+++ b/src/xmipp3_installer/application/cli/parsers/base_help_formatter.py
@@ -87,7 +87,7 @@ class BaseHelpFormatter(argparse.HelpFormatter):
     ### Returns:
     - (bool): True if all elements in the list are strings, False otherwise.
     """
-    return not all(isinstance(arg, str) for arg in arg_list)
+    return any(isinstance(arg, list) for arg in arg_list)
 
   @staticmethod
   def __get_text_length(text: str) -> int:

--- a/src/xmipp3_installer/application/cli/parsers/base_help_formatter.py
+++ b/src/xmipp3_installer/application/cli/parsers/base_help_formatter.py
@@ -2,7 +2,7 @@
 
 import argparse
 import shutil
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from xmipp3_installer.application.cli.arguments import modes, params
 from xmipp3_installer.application.cli.parsers import format
@@ -77,7 +77,7 @@ class BaseHelpFormatter(argparse.HelpFormatter):
     return f"{previous_text}{fill_in_space}{formatted_help}\n"
 
   @staticmethod
-  def _has_mutually_exclusive_groups(arg_list: List[str | List[str]]) -> bool:
+  def _has_mutually_exclusive_groups(arg_list: List[Union[str, List[str]]]) -> bool:
     """
     ### Checks if the param list provided contains mutually exclusive groups.
 

--- a/src/xmipp3_installer/application/cli/parsers/base_help_formatter.py
+++ b/src/xmipp3_installer/application/cli/parsers/base_help_formatter.py
@@ -10,7 +10,7 @@ from xmipp3_installer.application.cli.parsers import format
 class BaseHelpFormatter(argparse.HelpFormatter):
   """### Extendes the available functions of the generic help formatter."""
 
-  __SECTION_N_DASH = 45
+  __SECTION_N_DASH = 68
   __SECTION_SPACE_MODE_HELP = 2
   __SECTION_HELP_START = format.TAB_SIZE + __SECTION_N_DASH + __SECTION_SPACE_MODE_HELP
   __LINE_SIZE_LOWER_LIMIT = int(__SECTION_HELP_START * 1.5)
@@ -75,6 +75,19 @@ class BaseHelpFormatter(argparse.HelpFormatter):
       self.__get_start_section_fill_in_space('')
     )
     return f"{previous_text}{fill_in_space}{formatted_help}\n"
+
+  @staticmethod
+  def _has_mutually_exclusive_groups(arg_list: List[str | List[str]]) -> bool:
+    """
+    ### Checks if the param list provided contains mutually exclusive groups.
+
+    ### Params:
+    - arg_list (list[str | list[str]]): List of arguments, which can be strings or lists of strings.
+
+    ### Returns:
+    - (bool): True if all elements in the list are strings, False otherwise.
+    """
+    return not all(isinstance(arg, str) for arg in arg_list)
 
   @staticmethod
   def __get_text_length(text: str) -> int:

--- a/src/xmipp3_installer/application/cli/parsers/general_help_formatter.py
+++ b/src/xmipp3_installer/application/cli/parsers/general_help_formatter.py
@@ -13,10 +13,27 @@ class GeneralHelpFormatter(BaseHelpFormatter):
     help_message = "Run Xmipp's installer script\n\nUsage: xmipp [options]\n"
     for section in list(modes.MODES.keys()):
       help_message += self.__get_section_message(section)
-    help_message += f"\n{GeneralHelpFormatter.__get_epilog()}"
-    help_message += GeneralHelpFormatter.__get_note()
+    help_message += f"\n{self.__get_epilog()}"
+    help_message += self.__get_note()
     return format.get_formatting_tabs(help_message)
   
+  def __get_mode_arg_group_str(self, args: str) -> str:
+    """
+    ### This method returns the args text for a given arg group.
+
+    ### Params:
+    - args (str): Args to format into a message string.
+
+    ### Returns:
+    - (str): Args text for given mode.
+    """
+    param_names = []
+    for param in args:
+      param_name = self._get_param_first_name(param)
+      if param_name:
+        param_names.append(f'[{param_name}]')
+    return ' '.join(param_names)
+
   def __get_mode_args_str(self, mode: str) -> str:
     """
     ### This method returns the args text for a given mode.
@@ -27,13 +44,15 @@ class GeneralHelpFormatter(BaseHelpFormatter):
     ### Returns:
     - (str): Args text for given mode.
     """
-    arg_list = modes.MODE_ARGS[mode]
-    param_names = []
-    for param in arg_list:
-      param_name = self._get_param_first_name(param)
-      if param_name:
-        param_names.append(f'[{param_name}]')
-    return ' '.join(param_names)
+    args = modes.MODE_ARGS[mode]
+    if not self._has_mutually_exclusive_groups(args):
+      return self.__get_mode_arg_group_str(args)
+    
+    group_strs = [
+      self.__get_mode_arg_group_str(arg_group) for arg_group in args
+    ]
+    exclusive_group_str = " | ".join(group_strs)
+    return f"({exclusive_group_str})"
 
   def __get_mode_args_and_help_str(self, previous_text: str, mode: str) -> str:
     """

--- a/src/xmipp3_installer/application/cli/parsers/mode_help_formatter.py
+++ b/src/xmipp3_installer/application/cli/parsers/mode_help_formatter.py
@@ -16,7 +16,7 @@ class ModeHelpFormatter(BaseHelpFormatter):
     mode = self.__get_mode()
     help_message = f"{self._get_mode_help(mode, general=False)}\n\n"
     help_message += self.__get_args_message(mode)
-    help_message += ModeHelpFormatter.__get_examples_message(mode)
+    help_message += self.__get_examples_message(mode)
     return format.get_formatting_tabs(help_message)
 
   def __get_mode(self):
@@ -48,13 +48,13 @@ class ModeHelpFormatter(BaseHelpFormatter):
     
     if len(args) > 0:
       arg_names = [self._get_param_first_name(arg_name) for arg_name in args]
-      if ModeHelpFormatter.__args_contain_optional(arg_names):
+      if self.__args_contain_optional(arg_names):
         help_message += logger.yellow("Note: only params starting with '-' are optional. The rest are required.\n")
       options_str = ' [options]'
       separator = self._get_help_separator() + '\t# Options #\n\n'
 
     help_message += f'Usage: {arguments.XMIPP_PROGRAM_NAME} {mode}{options_str}\n{separator}'
-    help_message += self.__get_args_info(args)
+    help_message += self.__get_args_group_info(args)
     return help_message
 
   @staticmethod
@@ -73,7 +73,7 @@ class ModeHelpFormatter(BaseHelpFormatter):
         return True
     return False
 
-  def __get_args_info(self, args: List[str]) -> str:
+  def __get_args_group_info(self, args: List[str]) -> str:
     """
     ### Returns the info of each param.
 

--- a/src/xmipp3_installer/application/cli/parsers/mode_help_formatter.py
+++ b/src/xmipp3_installer/application/cli/parsers/mode_help_formatter.py
@@ -1,6 +1,6 @@
 """### Help formatter specific for non-generic usage modes."""
 
-from typing import List
+from typing import List, Union
 
 from xmipp3_installer.application.cli import arguments
 from xmipp3_installer.application.cli.arguments import modes, params
@@ -80,7 +80,7 @@ class ModeHelpFormatter(BaseHelpFormatter):
         return True
     return False
 
-  def __get_args_info(self, args: List[str | List[str]]) -> str:
+  def __get_args_info(self, args: List[Union[str, List[str]]]) -> str:
     """
     ### Returns the info of each param.
 
@@ -134,7 +134,7 @@ class ModeHelpFormatter(BaseHelpFormatter):
 
     return help_message
 
-  def __flatten_args(self, args: List[str | List[str]]) -> List[str]:
+  def __flatten_args(self, args: List[Union[str, List[str]]]) -> List[str]:
     """
     ### Flattens a list of arguments.
 

--- a/src/xmipp3_installer/installer/modes/mode_sync/mode_test_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_sync/mode_test_executor.py
@@ -90,7 +90,11 @@ class ModeTestExecutor(ModeSyncExecutor):
     - (tuple(int, str)): Tuple containing the return code and an error message if there was an error.
     """
     no_cuda_str = "--noCuda" if not self.cuda else ""
-    if _TESTS_SEPARATOR in self.param_value:
+    if self.param_value not in {
+      _PARAM_MAPPER[params.PARAM_SHOW_TESTS],
+      _PARAM_MAPPER[params.PARAM_ALL_FUNCTIONS],
+      _PARAM_MAPPER[params.PARAM_ALL_PROGRAMS]
+    }:
       test_names = self.param_value.replace(_TESTS_SEPARATOR, ", ")
       logger(f" Tests to run: {test_names}")
     return shell_handler.run_shell_command(

--- a/src/xmipp3_installer/installer/modes/mode_sync/mode_test_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_sync/mode_test_executor.py
@@ -104,7 +104,8 @@ class ModeTestExecutor(ModeSyncExecutor):
       show_error=True
     )
 
-  def __get_selected_param_value(self, context: Dict[str, Any]) -> str:
+  @staticmethod
+  def __get_selected_param_value(context: Dict[str, Any]) -> str:
     """
     ### Returns the value of the param selected to run the test execution.
 

--- a/src/xmipp3_installer/installer/modes/mode_sync/mode_test_executor.py
+++ b/src/xmipp3_installer/installer/modes/mode_sync/mode_test_executor.py
@@ -19,8 +19,8 @@ _PYTHON_TEST_SCRIPT_NAME = "test.py"
 _PYTHON_TEST_SCRIPT_PATH = os.path.join(paths.SOURCES_PATH, "xmipp", "tests")
 _DEFAULT_PYTHON_HOME = "python3"
 _DATASET_PATH = os.path.join(_PYTHON_TEST_SCRIPT_PATH, 'data')
-__TESTS_SEPARATOR = " "
-__PARAM_MAPPER = {
+_TESTS_SEPARATOR = " "
+_PARAM_MAPPER = {
   params.PARAM_SHOW_TESTS: "--show",
   params.PARAM_ALL_FUNCTIONS: "--allFuncs",
   params.PARAM_ALL_PROGRAMS: "--allPrograms"
@@ -90,8 +90,8 @@ class ModeTestExecutor(ModeSyncExecutor):
     - (tuple(int, str)): Tuple containing the return code and an error message if there was an error.
     """
     no_cuda_str = "--noCuda" if not self.cuda else ""
-    if __TESTS_SEPARATOR in self.param_value:
-      test_names = self.param_value.replace(",", "")
+    if _TESTS_SEPARATOR in self.param_value:
+      test_names = self.param_value.replace(_TESTS_SEPARATOR, ", ")
       logger(f" Tests to run: {test_names}")
     return shell_handler.run_shell_command(
       f"{self.python_home} {_PYTHON_TEST_SCRIPT_NAME} {self.param_value} {no_cuda_str}",
@@ -116,5 +116,5 @@ class ModeTestExecutor(ModeSyncExecutor):
       params.PARAM_ALL_PROGRAMS
     }:
       if context[variable]:
-        return __PARAM_MAPPER[variable]
-    return __TESTS_SEPARATOR.join(context.pop(params.PARAM_TEST_NAMES))
+        return _PARAM_MAPPER[variable]
+    return _TESTS_SEPARATOR.join(context.pop(params.PARAM_TEST_NAMES))

--- a/tests/e2e/mode_test_test.py
+++ b/tests/e2e/mode_test_test.py
@@ -21,73 +21,92 @@ from .. import (
 
 __INDIVIDUAL_TEST = "test1"
 __MULTIPLE_TESTS = f"{__INDIVIDUAL_TEST} test2 test3"
+__SHOW_PARAM = "--show"
+__ALL_FUNCTIONS_PARAM = "--all-functions"
+__ALL_PROGRAMS_PARAM = "--all-programs"
 
 @pytest.mark.parametrize(
-  "__mock_sync_program_path,__mock_dataset_path,__mock_sys_argv,show,expected_message",
+  "__mock_sync_program_path,__mock_dataset_path,__mock_sys_argv,expected_message",
   [
     pytest.param(
-      False, False, __INDIVIDUAL_TEST, False, mode_sync.NO_PROGRAM,
-      id="Non-existing program, no dataset, individual test, no show"
+      False, False, __INDIVIDUAL_TEST, mode_sync.NO_PROGRAM,
+      id="Non-existing program, no dataset, individual test"
     ),
     pytest.param(
-      False, False, __INDIVIDUAL_TEST, True, mode_sync.NO_PROGRAM,
-      id="Non-existing program, no dataset, individual test, show"
+      False, False, __MULTIPLE_TESTS, mode_sync.NO_PROGRAM,
+      id="Non-existing program, no dataset, multiple tests"
     ),
     pytest.param(
-      False, False, __MULTIPLE_TESTS, False, mode_sync.NO_PROGRAM,
-      id="Non-existing program, no dataset, multiple tests, no show"
+      False, False, __SHOW_PARAM, mode_sync.NO_PROGRAM,
+      id="Non-existing program, no dataset, show"
     ),
     pytest.param(
-      False, False, __MULTIPLE_TESTS, True, mode_sync.NO_PROGRAM,
-      id="Non-existing program, no dataset, multiple tests, show"
+      False, False, __ALL_FUNCTIONS_PARAM, mode_sync.NO_PROGRAM,
+      id="Non-existing program, no dataset, all functions"
     ),
     pytest.param(
-      False, True, __INDIVIDUAL_TEST, False, mode_sync.NO_PROGRAM,
-      id="Non-existing program, existing dataset, individual test, no show"
+      False, False, __ALL_PROGRAMS_PARAM, mode_sync.NO_PROGRAM,
+      id="Non-existing program, no dataset, all programs"
     ),
     pytest.param(
-      False, True, __INDIVIDUAL_TEST, True, mode_sync.NO_PROGRAM,
-      id="Non-existing program, existing dataset, individual test, show"
+      False, True, __INDIVIDUAL_TEST, mode_sync.NO_PROGRAM,
+      id="Non-existing program, existing dataset, individual test"
     ),
     pytest.param(
-      False, True, __MULTIPLE_TESTS, False, mode_sync.NO_PROGRAM,
-      id="Non-existing program, existing dataset, multiple tests, no show"
+      False, True, __MULTIPLE_TESTS, mode_sync.NO_PROGRAM,
+      id="Non-existing program, existing dataset, multiple tests"
     ),
     pytest.param(
-      False, True, __MULTIPLE_TESTS, True, mode_sync.NO_PROGRAM,
-      id="Non-existing program, existing dataset, multiple tests, show"
+      False, True, __SHOW_PARAM, mode_sync.NO_PROGRAM,
+      id="Non-existing program, existing dataset, show"
     ),
     pytest.param(
-      True, False, __INDIVIDUAL_TEST, False, mode_test.get_download_message(__INDIVIDUAL_TEST),
-      id="Existing program, no dataset, individual test, no show"
+      False, True, __ALL_FUNCTIONS_PARAM, mode_sync.NO_PROGRAM,
+      id="Non-existing program, existing dataset, all functions"
     ),
     pytest.param(
-      True, False, __INDIVIDUAL_TEST, True, mode_test.get_download_message(__INDIVIDUAL_TEST),
-      id="Existing program, no dataset, individual test, show"
+      False, True, __ALL_PROGRAMS_PARAM, mode_sync.NO_PROGRAM,
+      id="Non-existing program, existing dataset, all programs"
     ),
     pytest.param(
-      True, False, __MULTIPLE_TESTS, False, mode_test.get_download_message(__MULTIPLE_TESTS),
-      id="Existing program, no dataset, multiple tests, no show"
+      True, False, __INDIVIDUAL_TEST, mode_test.get_download_message(__INDIVIDUAL_TEST),
+      id="Existing program, no dataset, individual test"
     ),
     pytest.param(
-      True, False, __MULTIPLE_TESTS, True, mode_test.get_download_message(__MULTIPLE_TESTS),
-      id="Existing program, no dataset, multiple tests, show"
+      True, False, __MULTIPLE_TESTS, mode_test.get_download_message(__MULTIPLE_TESTS),
+      id="Existing program, no dataset, multiple tests"
     ),
     pytest.param(
-      True, True, __INDIVIDUAL_TEST, False, mode_test.get_update_message(__INDIVIDUAL_TEST),
-      id="Existing program, existing dataset, individual test, no show"
+      True, False, __SHOW_PARAM, mode_test.get_download_message(""),
+      id="Existing program, no dataset, show"
     ),
     pytest.param(
-      True, True, __INDIVIDUAL_TEST, True, mode_test.get_update_message(__INDIVIDUAL_TEST),
-      id="Existing program, existing dataset, individual test, show"
+      True, False, __ALL_FUNCTIONS_PARAM, mode_test.get_download_message(""),
+      id="Existing program, no dataset, all functions"
     ),
     pytest.param(
-      True, True, __MULTIPLE_TESTS, False, mode_test.get_update_message(__MULTIPLE_TESTS),
-      id="Existing program, existing dataset, multiple tests, no show"
+      True, False, __ALL_PROGRAMS_PARAM, mode_test.get_download_message(""),
+      id="Existing program, no dataset, all programs"
     ),
     pytest.param(
-      True, True, __MULTIPLE_TESTS, True, mode_test.get_update_message(__MULTIPLE_TESTS),
-      id="Existing program, existing dataset, multiple tests, show"
+      True, True, __INDIVIDUAL_TEST, mode_test.get_update_message(__INDIVIDUAL_TEST),
+      id="Existing program, existing dataset, individual test"
+    ),
+    pytest.param(
+      True, True, __MULTIPLE_TESTS, mode_test.get_update_message(__MULTIPLE_TESTS),
+      id="Existing program, existing dataset, multiple tests"
+    ),
+    pytest.param(
+      True, True, __SHOW_PARAM, mode_test.get_update_message(""),
+      id="Existing program, existing dataset, show"
+    ),
+    pytest.param(
+      True, True, __ALL_FUNCTIONS_PARAM, mode_test.get_update_message(""),
+      id="Existing program, existing dataset, all functions"
+    ),
+    pytest.param(
+      True, True, __ALL_PROGRAMS_PARAM, mode_test.get_update_message(""),
+      id="Existing program, existing dataset, all programs"
     )
   ],
   indirect=["__mock_sync_program_path", "__mock_dataset_path", "__mock_sys_argv"]
@@ -95,14 +114,11 @@ __MULTIPLE_TESTS = f"{__INDIVIDUAL_TEST} test2 test3"
 def test_add_model(
   __mock_sync_program_path,
   __mock_sys_argv,
-  show,
   expected_message,
   __mock_stdout_stderr,
   __setup_environment
 ):
   stdout, _ = __mock_stdout_stderr
-  if show:
-    __mock_sys_argv.append(params.PARAMS[params.PARAM_SHOW_TESTS][params.LONG_VERSION])
   with pytest.raises(SystemExit):
     cli.main()
   output = normalize_text_line_endings(stdout.getvalue())

--- a/tests/e2e/mode_test_test.py
+++ b/tests/e2e/mode_test_test.py
@@ -6,7 +6,7 @@ import pytest
 
 from xmipp3_installer.application.cli import cli
 from xmipp3_installer.application.cli import arguments
-from xmipp3_installer.application.cli.arguments import modes, params
+from xmipp3_installer.application.cli.arguments import modes
 from xmipp3_installer.installer.constants import paths
 from xmipp3_installer.installer.modes.mode_sync import mode_sync_executor
 from xmipp3_installer.installer.modes.mode_sync import mode_test_executor

--- a/tests/e2e/shell_command_outputs/mode_sync/mode_test.py
+++ b/tests/e2e/shell_command_outputs/mode_sync/mode_test.py
@@ -3,11 +3,13 @@ from xmipp3_installer.application.logger.logger import logger
 from ....test_files import xmipp_sync_data, test
 
 def get_test_messages_section(test_names: str) -> str:
-  test_names_str = ' '.join(test_names)
+  if not test_names:
+    return test.MESSAGE
+  test_names_str = ', '.join(test_names)
   return f" Tests to run: {test_names_str}\n{test.MESSAGE}"
 
 def get_download_message(test_params: str) -> str:
-  test_names = test_params.split(" ")
+  test_names = test_params.split(" ") if test_params else []
   return "\n".join([
     logger.blue("Downloading the test files"),
     xmipp_sync_data.MESSAGE,
@@ -16,7 +18,7 @@ def get_download_message(test_params: str) -> str:
 	])
 
 def get_update_message(test_params: str) -> str:
-  test_names = test_params.split(" ")
+  test_names = test_params.split(" ") if test_params else []
   return "\n".join([
     logger.blue("Updating the test files"),
     get_test_messages_section(test_names),

--- a/tests/integration/application/cli/general_message.py
+++ b/tests/integration/application/cli/general_message.py
@@ -7,39 +7,39 @@ __NOTE_MESSAGE = logger.yellow(
 )
 
 HELP_MESSAGE = {
-  terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Run Xmipp's installer script
+  terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Run Xmipp\'s installer script
 
 Usage: xmipp [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # General #
 
-    version [--short]                              Returns the version information. Add '--short' to print only the version number.
-    compileAndInstall [-j] [--keep-output]         Compiles and installs Xmipp based on already obtained sources.
-    all [-j] [-b] [--keep-output]                  Default param. Runs config, configBuild, and compileAndInstall.
-    configBuild [--keep-output]                    Configures the project with CMake.
-    ---------------------------------------------
+    version [--short]                                                     Returns the version information. Add \'--short\' to print only the version number.
+    compileAndInstall [-j] [--keep-output]                                Compiles and installs Xmipp based on already obtained sources.
+    all [-j] [-b] [--keep-output]                                         Default param. Runs config, configBuild, and compileAndInstall.
+    configBuild [--keep-output]                                           Configures the project with CMake.
+    --------------------------------------------------------------------
     # Config #
 
-    config [-o]                                    Generates a config file template with default values.
-    ---------------------------------------------
+    config [-o]                                                           Generates a config file template with default values.
+    --------------------------------------------------------------------
     # Downloads #
 
-    getModels [-d]                                 Downloads the Deep Learning Models required by the DLTK tools at dir/models (dist by default).
-    getSources [-b] [--keep-output]                Clone all Xmipp's sources.
-    ---------------------------------------------
+    getModels [-d]                                                        Downloads the Deep Learning Models required by the DLTK tools at dir/models (dist by default).
+    getSources [-b] [--keep-output]                                       Clone all Xmipp\'s sources.
+    --------------------------------------------------------------------
     # Clean #
 
-    cleanBin                                       Removes all compiled binaries.
-    cleanAll                                       Removes all compiled binaries and sources, leaves the repository as if freshly cloned (without pulling).
-    ---------------------------------------------
+    cleanBin                                                              Removes all compiled binaries.
+    cleanAll                                                              Removes all compiled binaries and sources, leaves the repository as if freshly cloned (without pulling).
+    --------------------------------------------------------------------
     # Test #
 
-    test [testNames] [--show]                      Runs a given test.
-    ---------------------------------------------
+    test ([testNames] | [--show] | [--all-functions] | [--all-programs])  Runs Xmipp\'s tests.
+    --------------------------------------------------------------------
     # Developers #
 
-    git [command]                                  Runs the given git action for all source repositories.
-    addModel [login] [modelPath] [--update]        Takes a DeepLearning model from the modelPath, makes a tgz of it and uploads the .tgz according to the <login>.
+    git [command]                                                         Runs the given git action for all source repositories.
+    addModel [login] [modelPath] [--update]                               Takes a DeepLearning model from the modelPath, makes a tgz of it and uploads the .tgz according to the <login>.
 
 Example 1: ./xmipp
 Example 2: ./xmipp compileAndInstall -j 4
@@ -47,62 +47,49 @@ Example 2: ./xmipp compileAndInstall -j 4
   terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Run Xmipp\'s installer script
 
 Usage: xmipp [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # General #
 
-    version [--short]                              Returns the version
-                                                   information. Add
-                                                   \'--short\' to print only
-                                                   the version number.
-    compileAndInstall [-j] [--keep-output]         Compiles and installs
-                                                   Xmipp based on already
-                                                   obtained sources.
-    all [-j] [-b] [--keep-output]                  Default param. Runs
-                                                   config, configBuild, and
-                                                   compileAndInstall.
-    configBuild [--keep-output]                    Configures the project
-                                                   with CMake.
-    ---------------------------------------------
+    version [--short]                                                     Returns the version information. Add
+                                                                          \'--short\' to print only the version
+                                                                          number.
+    compileAndInstall [-j] [--keep-output]                                Compiles and installs Xmipp based on
+                                                                          already obtained sources.
+    all [-j] [-b] [--keep-output]                                         Default param. Runs config,
+                                                                          configBuild, and compileAndInstall.
+    configBuild [--keep-output]                                           Configures the project with CMake.
+    --------------------------------------------------------------------
     # Config #
 
-    config [-o]                                    Generates a config file
-                                                   template with default
-                                                   values.
-    ---------------------------------------------
+    config [-o]                                                           Generates a config file template with
+                                                                          default values.
+    --------------------------------------------------------------------
     # Downloads #
 
-    getModels [-d]                                 Downloads the Deep
-                                                   Learning Models required
-                                                   by the DLTK tools at
-                                                   dir/models (dist by
-                                                   default).
-    getSources [-b] [--keep-output]                Clone all Xmipp\'s
-                                                   sources.
-    ---------------------------------------------
+    getModels [-d]                                                        Downloads the Deep Learning Models
+                                                                          required by the DLTK tools at
+                                                                          dir/models (dist by default).
+    getSources [-b] [--keep-output]                                       Clone all Xmipp\'s sources.
+    --------------------------------------------------------------------
     # Clean #
 
-    cleanBin                                       Removes all compiled
-                                                   binaries.
-    cleanAll                                       Removes all compiled
-                                                   binaries and sources,
-                                                   leaves the repository as
-                                                   if freshly cloned
-                                                   (without pulling).
-    ---------------------------------------------
+    cleanBin                                                              Removes all compiled binaries.
+    cleanAll                                                              Removes all compiled binaries and
+                                                                          sources, leaves the repository as if
+                                                                          freshly cloned (without pulling).
+    --------------------------------------------------------------------
     # Test #
 
-    test [testNames] [--show]                      Runs a given test.
-    ---------------------------------------------
+    test ([testNames] | [--show] | [--all-functions] | [--all-programs])  Runs Xmipp\'s tests.
+    --------------------------------------------------------------------
     # Developers #
 
-    git [command]                                  Runs the given git action
-                                                   for all source
-                                                   repositories.
-    addModel [login] [modelPath] [--update]        Takes a DeepLearning
-                                                   model from the modelPath,
-                                                   makes a tgz of it and
-                                                   uploads the .tgz
-                                                   according to the <login>.
+    git [command]                                                         Runs the given git action for all
+                                                                          source repositories.
+    addModel [login] [modelPath] [--update]                               Takes a DeepLearning model from the
+                                                                          modelPath, makes a tgz of it and
+                                                                          uploads the .tgz according to the
+                                                                          <login>.
 
 Example 1: ./xmipp
 Example 2: ./xmipp compileAndInstall -j 4

--- a/tests/integration/application/cli/mode_messages/mode_add_model.py
+++ b/tests/integration/application/cli/mode_messages/mode_add_model.py
@@ -18,12 +18,12 @@ The model name will be the folder name in <modelsPath>
 Must have write permissions to such machine.
 
 {NOTE_MESSAGE}Usage: xmipp addModel [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    login                                          Login (usr@server) for remote host to upload the model with. Must have write permissions to such machine.
-    modelPath                                      Path to the model to upload to remote host.
-    --update                                       Flag to update an existing model
+    login                                                                 Login (usr@server) for remote host to upload the model with. Must have write permissions to such machine.
+    modelPath                                                             Path to the model to upload to remote host.
+    --update                                                              Flag to update an existing model
 
 Example: ./xmipp addModel myuser@127.0.0.1 /home/myuser/mymodel
 """,
@@ -43,18 +43,15 @@ The model name will be the folder name in <modelsPath>
 Must have write permissions to such machine.
 
 {NOTE_MESSAGE}Usage: xmipp addModel [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    login                                          Login (usr@server) for
-                                                   remote host to upload the
-                                                   model with. Must have
-                                                   write permissions to such
-                                                   machine.
-    modelPath                                      Path to the model to
-                                                   upload to remote host.
-    --update                                       Flag to update an
-                                                   existing model
+    login                                                                 Login (usr@server) for remote host to
+                                                                          upload the model with. Must have
+                                                                          write permissions to such machine.
+    modelPath                                                             Path to the model to upload to remote
+                                                                          host.
+    --update                                                              Flag to update an existing model
 
 Example: ./xmipp addModel myuser@127.0.0.1 /home/myuser/mymodel
 """

--- a/tests/integration/application/cli/mode_messages/mode_all.py
+++ b/tests/integration/application/cli/mode_messages/mode_all.py
@@ -5,12 +5,12 @@ HELP_MESSAGE = {
   terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Default param. Runs config, configBuild, and compileAndInstall.
 
 {NOTE_MESSAGE}Usage: xmipp all [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -j, --jobs                                     Number of jobs. Defaults to all available.
-    -b, --branch                                   Branch for the source repositories.
-    --keep-output                                  If set, output sent through the terminal won't substitute lines, looking more like the log.
+    -j, --jobs                                                            Number of jobs. Defaults to all available.
+    -b, --branch                                                          Branch for the source repositories.
+    --keep-output                                                         If set, output sent through the terminal won't substitute lines, looking more like the log.
 
 Example 1: ./xmipp
 Example 2: ./xmipp all
@@ -21,18 +21,15 @@ Example 5: ./xmipp all -j 20 -b devel
   terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Default param. Runs config, configBuild, and compileAndInstall.
 
 {NOTE_MESSAGE}Usage: xmipp all [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -j, --jobs                                     Number of jobs. Defaults
-                                                   to all available.
-    -b, --branch                                   Branch for the source
-                                                   repositories.
-    --keep-output                                  If set, output sent
-                                                   through the terminal
-                                                   won't substitute lines,
-                                                   looking more like the
-                                                   log.
+    -j, --jobs                                                            Number of jobs. Defaults to all
+                                                                          available.
+    -b, --branch                                                          Branch for the source repositories.
+    --keep-output                                                         If set, output sent through the
+                                                                          terminal won't substitute lines,
+                                                                          looking more like the log.
 
 Example 1: ./xmipp
 Example 2: ./xmipp all

--- a/tests/integration/application/cli/mode_messages/mode_compile_and_install.py
+++ b/tests/integration/application/cli/mode_messages/mode_compile_and_install.py
@@ -5,11 +5,11 @@ HELP_MESSAGE = {
   terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Compiles and installs Xmipp based on already obtained sources.
 
 {NOTE_MESSAGE}Usage: xmipp compileAndInstall [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -j, --jobs                                     Number of jobs. Defaults to all available.
-    --keep-output                                  If set, output sent through the terminal won't substitute lines, looking more like the log.
+    -j, --jobs                                                            Number of jobs. Defaults to all available.
+    --keep-output                                                         If set, output sent through the terminal won't substitute lines, looking more like the log.
 
 Example 1: ./xmipp compileAndInstall
 Example 2: ./xmipp compileAndInstall -j 20
@@ -17,16 +17,14 @@ Example 2: ./xmipp compileAndInstall -j 20
   terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Compiles and installs Xmipp based on already obtained sources.
 
 {NOTE_MESSAGE}Usage: xmipp compileAndInstall [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -j, --jobs                                     Number of jobs. Defaults
-                                                   to all available.
-    --keep-output                                  If set, output sent
-                                                   through the terminal
-                                                   won't substitute lines,
-                                                   looking more like the
-                                                   log.
+    -j, --jobs                                                            Number of jobs. Defaults to all
+                                                                          available.
+    --keep-output                                                         If set, output sent through the
+                                                                          terminal won't substitute lines,
+                                                                          looking more like the log.
 
 Example 1: ./xmipp compileAndInstall
 Example 2: ./xmipp compileAndInstall -j 20

--- a/tests/integration/application/cli/mode_messages/mode_config.py
+++ b/tests/integration/application/cli/mode_messages/mode_config.py
@@ -5,22 +5,21 @@ HELP_MESSAGE = {
   terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Generates a config file template with default values.
 
 {NOTE_MESSAGE}Usage: xmipp config [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -o, --overwrite                                If set, current config file will be overwritten with a new one.
+    -o, --overwrite                                                       If set, current config file will be overwritten with a new one.
 
 Example: ./xmipp config --overwrite
 """,
   terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Generates a config file template with default values.
 
 {NOTE_MESSAGE}Usage: xmipp config [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -o, --overwrite                                If set, current config
-                                                   file will be overwritten
-                                                   with a new one.
+    -o, --overwrite                                                       If set, current config file will be
+                                                                          overwritten with a new one.
 
 Example: ./xmipp config --overwrite
 """

--- a/tests/integration/application/cli/mode_messages/mode_config_build.py
+++ b/tests/integration/application/cli/mode_messages/mode_config_build.py
@@ -5,21 +5,19 @@ HELP_MESSAGE = {
   terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Configures the project with CMake.
 
 {NOTE_MESSAGE}Usage: xmipp configBuild [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    --keep-output                                  If set, output sent through the terminal won't substitute lines, looking more like the log.
+    --keep-output                                                         If set, output sent through the terminal won't substitute lines, looking more like the log.
 """,
   terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Configures the project with CMake.
 
 {NOTE_MESSAGE}Usage: xmipp configBuild [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    --keep-output                                  If set, output sent
-                                                   through the terminal
-                                                   won't substitute lines,
-                                                   looking more like the
-                                                   log.
+    --keep-output                                                         If set, output sent through the
+                                                                          terminal won't substitute lines,
+                                                                          looking more like the log.
 """
 }

--- a/tests/integration/application/cli/mode_messages/mode_get_models.py
+++ b/tests/integration/application/cli/mode_messages/mode_get_models.py
@@ -6,10 +6,10 @@ HELP_MESSAGE = {
 Visit https://i2pc.github.io/docs/Installation/Optionals/index.html#deeplearningtoolkit for more details.
 
 {NOTE_MESSAGE}Usage: xmipp getModels [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -d, --directory                                Directory where models will be saved. Default is "dist".
+    -d, --directory                                                       Directory where models will be saved. Default is "dist".
 
 Example 1: ./xmipp getModels
 Example 2: ./xmipp getModels -d /path/to/my/model/directory
@@ -18,12 +18,11 @@ Example 2: ./xmipp getModels -d /path/to/my/model/directory
 Visit https://i2pc.github.io/docs/Installation/Optionals/index.html#deeplearningtoolkit for more details.
 
 {NOTE_MESSAGE}Usage: xmipp getModels [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -d, --directory                                Directory where models
-                                                   will be saved. Default is
-                                                   "dist".
+    -d, --directory                                                       Directory where models will be saved.
+                                                                          Default is "dist".
 
 Example 1: ./xmipp getModels
 Example 2: ./xmipp getModels -d /path/to/my/model/directory

--- a/tests/integration/application/cli/mode_messages/mode_get_sources.py
+++ b/tests/integration/application/cli/mode_messages/mode_get_sources.py
@@ -5,27 +5,24 @@ HELP_MESSAGE = {
   terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Clone all Xmipp's sources.
 
 {NOTE_MESSAGE}Usage: xmipp getSources [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -b, --branch                                   Branch for the source repositories.
-    --keep-output                                  If set, output sent through the terminal won't substitute lines, looking more like the log.
+    -b, --branch                                                          Branch for the source repositories.
+    --keep-output                                                         If set, output sent through the terminal won't substitute lines, looking more like the log.
 
 Example: ./xmipp getSources./xmipp getSources -b devel
 """,
   terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Clone all Xmipp's sources.
 
 {NOTE_MESSAGE}Usage: xmipp getSources [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    -b, --branch                                   Branch for the source
-                                                   repositories.
-    --keep-output                                  If set, output sent
-                                                   through the terminal
-                                                   won't substitute lines,
-                                                   looking more like the
-                                                   log.
+    -b, --branch                                                          Branch for the source repositories.
+    --keep-output                                                         If set, output sent through the
+                                                                          terminal won't substitute lines,
+                                                                          looking more like the log.
 
 Example: ./xmipp getSources./xmipp getSources -b devel
 """

--- a/tests/integration/application/cli/mode_messages/mode_git.py
+++ b/tests/integration/application/cli/mode_messages/mode_git.py
@@ -4,10 +4,10 @@ HELP_MESSAGE = {
   terminal_sizes.LARGE_TERMINAL_WIDTH: """Runs the given git action for all source repositories.
 
 Usage: xmipp git [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    command                                        Git command to run on all source repositories.
+    command                                                               Git command to run on all source repositories.
 
 Example 1: ./xmipp git pull
 Example 2: ./xmipp git checkout devel
@@ -15,11 +15,11 @@ Example 2: ./xmipp git checkout devel
   terminal_sizes.SHORT_TERMINAL_WIDTH: """Runs the given git action for all source repositories.
 
 Usage: xmipp git [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    command                                        Git command to run on all
-                                                   source repositories.
+    command                                                               Git command to run on all source
+                                                                          repositories.
 
 Example 1: ./xmipp git pull
 Example 2: ./xmipp git checkout devel

--- a/tests/integration/application/cli/mode_messages/mode_test.py
+++ b/tests/integration/application/cli/mode_messages/mode_test.py
@@ -2,32 +2,55 @@ from .. import terminal_sizes
 from . import NOTE_MESSAGE
 
 HELP_MESSAGE = {
-  terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Runs a given test.
+  terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Runs Xmipp's tests.
+If used with 'testNames', only the tests provided will run.
+If used with '--show', a list the tests available and how to invoke them will be shown.
+If used with '--all-functions', all function tests will run.
+If used with '--all-programs', all program tests will run.
 
-{NOTE_MESSAGE}Usage: xmipp test [options]
-    ---------------------------------------------
+\x1b[93mImportant: In this mode, there are mutually exclusive groups of params. You can only use from one of them at a time.
+\x1b[0m{NOTE_MESSAGE}Usage: xmipp test [options]
+    --------------------------------------------------------------------
     # Options #
 
-    testNames                                      Name of the tests to run. If combined with --show, greps the test names from the test list.
-    --show                                         Shows the tests available and how to invoke those.
+    testNames                                                             Name of the tests to run.
+    ---------------
+    --show                                                                Shows the tests available and how to invoke those.
+    ---------------
+    --all-functions                                                       If set, all function tests will be run.
+    ---------------
+    --all-programs                                                        If set, all program tests will be run.
 
 Example 1: ./xmipp test xmipp_sample_test
-Example 2: ./xmipp test --short
+Example 2: ./xmipp test --show
+Example 3: ./xmipp test --all-functions
+Example 4: ./xmipp test --all-programs
 """,
-  terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Runs a given test.
+  terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Runs Xmipp's tests.
+If used with 'testNames', only the tests provided will run.
+If used with '--show', a list the tests available and how to invoke them will be shown.
+If used with '--all-functions', all function tests will run.
+If used with '--all-programs', all program tests will run.
 
-{NOTE_MESSAGE}Usage: xmipp test [options]
-    ---------------------------------------------
+\x1b[93mImportant: In this mode, there are mutually exclusive groups of params. You can only use from one of them at a time.
+\x1b[0m{NOTE_MESSAGE}Usage: xmipp test [options]
+    --------------------------------------------------------------------
     # Options #
 
-    testNames                                      Name of the tests to run.
-                                                   If combined with --show,
-                                                   greps the test names from
-                                                   the test list.
-    --show                                         Shows the tests available
-                                                   and how to invoke those.
+    testNames                                                             Name of the tests to run.
+    ---------------
+    --show                                                                Shows the tests available and how to
+                                                                          invoke those.
+    ---------------
+    --all-functions                                                       If set, all function tests will be
+                                                                          run.
+    ---------------
+    --all-programs                                                        If set, all program tests will be
+                                                                          run.
 
 Example 1: ./xmipp test xmipp_sample_test
-Example 2: ./xmipp test --short
+Example 2: ./xmipp test --show
+Example 3: ./xmipp test --all-functions
+Example 4: ./xmipp test --all-programs
 """
 }

--- a/tests/integration/application/cli/mode_messages/mode_version.py
+++ b/tests/integration/application/cli/mode_messages/mode_version.py
@@ -5,10 +5,10 @@ HELP_MESSAGE = {
   terminal_sizes.LARGE_TERMINAL_WIDTH: f"""Returns the version information. Add '--short' to print only the version number.
 
 {NOTE_MESSAGE}Usage: xmipp version [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    --short                                        If set, only version number is shown.
+    --short                                                               If set, only version number is shown.
 
 Example 1: ./xmipp version
 Example 2: ./xmipp version --short
@@ -16,11 +16,10 @@ Example 2: ./xmipp version --short
   terminal_sizes.SHORT_TERMINAL_WIDTH: f"""Returns the version information. Add '--short' to print only the version number.
 
 {NOTE_MESSAGE}Usage: xmipp version [options]
-    ---------------------------------------------
+    --------------------------------------------------------------------
     # Options #
 
-    --short                                        If set, only version
-                                                   number is shown.
+    --short                                                               If set, only version number is shown.
 
 Example 1: ./xmipp version
 Example 2: ./xmipp version --short

--- a/tests/unitary/application/cli/cli_test.py
+++ b/tests/unitary/application/cli/cli_test.py
@@ -251,7 +251,9 @@ def test_returns_expected_mode_git_args(
   "__mock_sys_argv,expected_args",
   [
     pytest.param(["test", "mytest", "test2"], {"testNames": ["mytest", "test2"]}),
-    pytest.param(["test", "mytest" , "--show"], {"testNames": ["mytest"], "show": True}),
+    pytest.param(["test", "--show"], {"show": True}),
+    pytest.param(["test", "--all-functions"], {"all_functions": True}),
+    pytest.param(["test", "--all-programs"], {"all_programs": True})
   ],
   indirect=["__mock_sys_argv"]
 )
@@ -263,7 +265,32 @@ def test_returns_expected_mode_test_args(
   __mock_run_installer,
   __mock_sys_exit
 ):
-  __test_args_in_mode("test", {"show": False}, expected_args, __mock_run_installer)
+  __test_args_in_mode(
+    "test",
+    {"testNames": [], "show": False, "all_functions": False, "all_programs": False},
+    expected_args,
+    __mock_run_installer
+  )
+
+@pytest.mark.parametrize(
+  "__mock_sys_argv",
+  [
+    pytest.param(["test", "mytest", "--show"]),
+    pytest.param(["test", "mytest", "--all-functions"]),
+    pytest.param(["test", "mytest", "--all-programs"]),
+    pytest.param(["test", "--show", "--all-functions"]),
+    pytest.param(["test", "--show", "--all-programs"]),
+    pytest.param(["test", "--all-functions", "--all-programs"])
+  ],
+  indirect=["__mock_sys_argv"]
+)
+def test_exits_due_to_mixed_use_of_mutually_exclusive_groups_on_mode_test_when_parsing_args(
+  __mock_sys_argv,
+  __mock_stdout_stderr
+):
+  with pytest.raises(SystemExit) as e:
+    cli.main()
+  assert e.value.code != 0
 
 @pytest.mark.parametrize(
   "__mock_sys_argv,expected_args",

--- a/tests/unitary/application/cli/parsers/base_help_formatter_test.py
+++ b/tests/unitary/application/cli/parsers/base_help_formatter_test.py
@@ -262,6 +262,28 @@ def test_returns_expected_spaces(
     (remaining_space, fill_in_space)
   )
 
+@pytest.mark.parametrize(
+  "args,expected_result",
+  [
+    pytest.param(["a", "b"], False),
+    pytest.param(["a", 1], True),
+    pytest.param(["a", ["b"]], True)
+  ]
+)
+def test_returns_expected_result_when_checking_if_args_have_mutually_exclusive_groups(
+  args,
+  expected_result,
+  __setup_parser
+):
+  result = __setup_parser._has_mutually_exclusive_groups(args)
+  assert (
+    result == expected_result
+  ), get_assertion_message(
+    "has mutually exclusive groups result",
+    expected_result,
+    result
+  )
+
 @pytest.fixture
 def __setup_parser():
   return BaseHelpFormatter("test")

--- a/tests/unitary/application/cli/parsers/base_help_formatter_test.py
+++ b/tests/unitary/application/cli/parsers/base_help_formatter_test.py
@@ -266,7 +266,7 @@ def test_returns_expected_spaces(
   "args,expected_result",
   [
     pytest.param(["a", "b"], False),
-    pytest.param(["a", 1], True),
+    pytest.param(["a", 1], False),
     pytest.param(["a", ["b"]], True)
   ]
 )

--- a/tests/unitary/application/cli/parsers/general_help_formatter_test.py
+++ b/tests/unitary/application/cli/parsers/general_help_formatter_test.py
@@ -31,7 +31,8 @@ __MODE_ARGS = {
   "mode2": ["param3", "param1"],
   "mode3": ["param2"],
   "mode4": ["param4"],
-  "mode5": []
+  "mode5": [],
+  "mode6": [["param1"], ["param2", "param3"]]
 }
 __MODES = {
   "section1": {
@@ -86,7 +87,8 @@ def test_calls_logger_yellow_when_getting_note(__setup_formatter, __mock_logger_
     pytest.param("mode2", "[param3-long] [param1-short]"),
     pytest.param("mode3", "[param2-short]"),
     pytest.param("mode4", ""),
-    pytest.param("mode5", "")
+    pytest.param("mode5", ""),
+    pytest.param("mode6", "([param1-short] | [param2-short] [param3-long])")
   ],
 )
 def test_gets_expected_mode_args_str(


### PR DESCRIPTION
Now mode `test` can only be used with one of 4 different params:
- `testNames`: Any number of tests names to run.
- `--show`: Shows the tests available.
- `--all-functions`: Runs all the function tests.
- `--all-programs`: Runs all the program tests.

Help message terminal output minimum size has had to be increased due to the length of the new param string for this mode.