### PR TITLE
Avoid sending statistics if there is no internet connection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xmipp3-installer"
-version = "2.1.0"
+version = "2.1.1"
 authors = [
   { name = "Martín Salinas", email = "ssalinasmartin@gmail.com" },
 ]

--- a/src/xmipp3_installer/api_client/__init__.py
+++ b/src/xmipp3_installer/api_client/__init__.py
@@ -1,0 +1,1 @@
+"""### Contains the API client for interacting with the Xmipp metrics server."""

--- a/src/xmipp3_installer/api_client/api_client.py
+++ b/src/xmipp3_installer/api_client/api_client.py
@@ -53,10 +53,10 @@ def internet_available() -> bool:
   try:
     socket.setdefaulttimeout(INTERNET_CHECK_TIMEOUT)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.connect((INTERNET_CHECK_IP, INTERNET_CHECK_PORT))
+      s.connect((INTERNET_CHECK_IP, INTERNET_CHECK_PORT))
     return True
   except OSError:
-      return False
+    return False
 
 
 def __get_https_connection(parsed_url: ParseResult, timeout_seconds: int) -> http.client.HTTPSConnection:

--- a/src/xmipp3_installer/api_client/api_client.py
+++ b/src/xmipp3_installer/api_client/api_client.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import http.client
 import json
+import socket
 from urllib.parse import ParseResult, urlparse
 
 from xmipp3_installer.application.logger.logger import logger
 from xmipp3_installer.installer import urls
+
+INTERNET_CHECK_TIMEOUT = 0.3
+INTERNET_CHECK_IP = "1.1.1.1" # Cloudflare DNS, chosen for its reliability and speed
+INTERNET_CHECK_PORT = 53 # DNS typically uses port 53, which is less likely to be blocked by firewalls compared to HTTP/HTTPS ports
 
 
 def send_installation_attempt(installation_info: dict):
@@ -35,6 +40,22 @@ def send_installation_attempt(installation_info: dict):
   finally:
     if conn is not None:
       conn.close()
+
+
+def internet_available() -> bool:
+  """
+  ### Checks if the internet is available by trying to connect to the API URL.
+
+  #### Returns:
+  - (bool): True if the connection was successful, False otherwise.
+  """
+  try:
+    socket.setdefaulttimeout(INTERNET_CHECK_TIMEOUT)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.connect((INTERNET_CHECK_IP, INTERNET_CHECK_PORT))
+    return True
+  except OSError:
+      return False
 
 
 def __get_https_connection(parsed_url: ParseResult, timeout_seconds: int) -> http.client.HTTPSConnection:

--- a/src/xmipp3_installer/api_client/api_client.py
+++ b/src/xmipp3_installer/api_client/api_client.py
@@ -6,6 +6,7 @@ import http.client
 import json
 import socket
 from urllib.parse import ParseResult, urlparse
+from typing import Optional
 
 from xmipp3_installer.application.logger.logger import logger
 from xmipp3_installer.installer import urls
@@ -15,7 +16,7 @@ INTERNET_CHECK_IP = "1.1.1.1" # Cloudflare DNS, chosen for its reliability and s
 INTERNET_CHECK_PORT = 53 # DNS typically uses port 53, which is less likely to be blocked by firewalls compared to HTTP/HTTPS ports
 
 
-def send_installation_attempt(installation_info: dict):
+def send_installation_attempt(installation_info: Optional[dict]):
   """
   ### Sends a POST request to Xmipp's metrics's API.
   

--- a/src/xmipp3_installer/api_client/api_client.py
+++ b/src/xmipp3_installer/api_client/api_client.py
@@ -6,7 +6,6 @@ import http.client
 import json
 import socket
 from urllib.parse import ParseResult, urlparse
-from typing import Optional
 
 from xmipp3_installer.application.logger.logger import logger
 from xmipp3_installer.installer import urls
@@ -16,7 +15,7 @@ INTERNET_CHECK_IP = "1.1.1.1" # Cloudflare DNS, chosen for its reliability and s
 INTERNET_CHECK_PORT = 53 # DNS typically uses port 53, which is less likely to be blocked by firewalls compared to HTTP/HTTPS ports
 
 
-def send_installation_attempt(installation_info: Optional[dict]):
+def send_installation_attempt(installation_info: dict | None):
   """
   ### Sends a POST request to Xmipp's metrics's API.
   

--- a/src/xmipp3_installer/installer/installer_service.py
+++ b/src/xmipp3_installer/installer/installer_service.py
@@ -60,10 +60,7 @@ class InstallationManager:
       return errors.INTERRUPTED_ERROR
     if ret_code:
       logger.log_error(output, ret_code=ret_code, add_portal_link=ret_code != errors.INTERRUPTED_ERROR)
-    if (
-      self.mode_executor.sends_installation_info and 
-      self.context[variables.SEND_INSTALLATION_STATISTICS]
-    ):
+    if self._should_send_installation_info():
       logger("Sending anonymous installation info...", show_in_terminal=False)
       api_client.send_installation_attempt(
         installation_info_assembler.get_installation_info(
@@ -80,3 +77,19 @@ class InstallationManager:
       ))
     logger.close()
     return ret_code
+
+  def _should_send_installation_info(self) -> bool:
+    """
+    ### Determines whether installation information should be sent to the server.
+
+    #### Returns:
+    - (bool): True if installation information should be sent, False otherwise.
+    """
+    if not self.mode_executor.sends_installation_info or not self.context[variables.SEND_INSTALLATION_STATISTICS]:
+      return False
+    
+    if not api_client.internet_available():
+      logger("No internet connection available. Installation info will not be sent.", show_in_terminal=False)
+      return False
+    
+    return True

--- a/tests/integration/api_client/api_client_test.py
+++ b/tests/integration/api_client/api_client_test.py
@@ -5,6 +5,7 @@ import ssl
 import tempfile
 import socket
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -39,7 +40,6 @@ def test_records_api_call_when_sending_installation_attempt(
 
 def test_internet_available_integration_true(httpserver, monkeypatch):
   httpserver.serve_content(content=None, code=200, store_request_data=True)
-  from urllib.parse import urlparse
 
   parsed = urlparse(httpserver.url)
   monkeypatch.setattr(api_client, "INTERNET_CHECK_IP", parsed.hostname)

--- a/tests/integration/api_client/api_client_test.py
+++ b/tests/integration/api_client/api_client_test.py
@@ -3,6 +3,7 @@ import os
 import shlex
 import ssl
 import tempfile
+import socket
 from unittest.mock import patch
 
 import pytest
@@ -35,6 +36,31 @@ def test_records_api_call_when_sending_installation_attempt(
   assert (
     __mock_server.requests[0].method == "POST"
   ), get_assertion_message("request method", "POST", __mock_server.requests[0].method)
+
+def test_internet_available_integration_true(httpserver, monkeypatch):
+  httpserver.serve_content(content=None, code=200, store_request_data=True)
+  from urllib.parse import urlparse
+
+  parsed = urlparse(httpserver.url)
+  monkeypatch.setattr(api_client, "INTERNET_CHECK_IP", parsed.hostname)
+  monkeypatch.setattr(api_client, "INTERNET_CHECK_PORT", parsed.port)
+  monkeypatch.setattr(api_client, "INTERNET_CHECK_TIMEOUT", 1.0)
+
+  assert api_client.internet_available() is True
+
+
+def test_internet_available_integration_false(monkeypatch):
+  # pick an ephemeral port and close it to simulate no-listener
+  s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+  s.bind(("127.0.0.1", 0))
+  _, port = s.getsockname()
+  s.close()
+
+  monkeypatch.setattr(api_client, "INTERNET_CHECK_IP", "127.0.0.1")
+  monkeypatch.setattr(api_client, "INTERNET_CHECK_PORT", port)
+  monkeypatch.setattr(api_client, "INTERNET_CHECK_TIMEOUT", 0.2)
+
+  assert api_client.internet_available() is False
 
 def __get_version_manager():
   class DummyVersionManager:

--- a/tests/unitary/api_client/api_client_test.py
+++ b/tests/unitary/api_client/api_client_test.py
@@ -12,72 +12,82 @@ __API_URL = "https://hostname/path"
 __PARSED_URL = urlparse(__API_URL)
 
 def test_does_not_call_httpsconnection_when_sending_empty_installation_attempt(
-  __mock_httpsconnection
+	__mock_httpsconnection
 ):
-  api_client.send_installation_attempt(None)
-  __mock_httpsconnection.assert_not_called()
+	api_client.send_installation_attempt(None)
+	__mock_httpsconnection.assert_not_called()
 
 def test_calls_httpsconnection_when_sending_installation_attempt(
-  __mock_httpsconnection
+	__mock_httpsconnection
 ):
-  api_client.send_installation_attempt({})
-  __mock_httpsconnection.assert_called_once_with(
-    __PARSED_URL.hostname,
-    __PARSED_URL.port,
-    timeout=6
-  )
+	api_client.send_installation_attempt({})
+	__mock_httpsconnection.assert_called_once_with(
+		__PARSED_URL.hostname,
+		__PARSED_URL.port,
+		timeout=6
+	)
 
 def test_calls_connection_request_when_sending_installation_attempt(
-  __mock_httpsconnection
+	__mock_httpsconnection
 ):
-  installation_info = {"var1": "value1", "var2": "value2"}
-  api_client.send_installation_attempt(installation_info)
-  __mock_httpsconnection().request.assert_called_once_with(
-    "POST",
-    __PARSED_URL.path,
-    body=json.dumps(installation_info),
-    headers={"Content-type": "application/json"}
-  )
+	installation_info = {"var1": "value1", "var2": "value2"}
+	api_client.send_installation_attempt(installation_info)
+	__mock_httpsconnection().request.assert_called_once_with(
+		"POST",
+		__PARSED_URL.path,
+		body=json.dumps(installation_info),
+		headers={"Content-type": "application/json"}
+	)
 
 def test_calls_connection_getresponse_when_sending_installation_attempt(
-  __mock_httpsconnection
+	__mock_httpsconnection
 ):
-  api_client.send_installation_attempt({})
-  __mock_httpsconnection().getresponse.assert_called_once_with()
+	api_client.send_installation_attempt({})
+	__mock_httpsconnection().getresponse.assert_called_once_with()
 
 def test_calls_logger_when_sending_installation_attempt_and_receives_timeout(
-  __mock_httpsconnection,
-  __mock_timeout,
-  __mock_logger,
-  __mock_logger_yellow
+	__mock_httpsconnection,
+	__mock_timeout,
+	__mock_logger,
+	__mock_logger_yellow
 ):
-  api_client.send_installation_attempt({})
-  __mock_logger.assert_called_once_with(
-     __mock_logger_yellow("There was a timeout while sending installation data."),
-     show_in_terminal=False
-  )
+	api_client.send_installation_attempt({})
+	__mock_logger.assert_called_once_with(
+		 __mock_logger_yellow("There was a timeout while sending installation data."),
+		 show_in_terminal=False
+	)
 
 def test_calls_connection_close_when_sending_installation_attempt(
-  __mock_httpsconnection
+	__mock_httpsconnection
 ):
-  api_client.send_installation_attempt({})
-  __mock_httpsconnection().close.assert_called_once_with()
+	api_client.send_installation_attempt({})
+	__mock_httpsconnection().close.assert_called_once_with()
+
+def test_internet_available_true(__mock_socket_available):
+	_, set_timeout, instance = __mock_socket_available
+
+	assert api_client.internet_available() is True
+	set_timeout.assert_called_once_with(api_client.INTERNET_CHECK_TIMEOUT)
+	instance.connect.assert_called_once_with((api_client.INTERNET_CHECK_IP, api_client.INTERNET_CHECK_PORT))
+
+def test_internet_available_false(__mock_socket_unavailable):
+	assert api_client.internet_available() is False
 
 @pytest.fixture
 def __mock_httpsconnection(__mock_api_url):
-  with patch.object(http.client, "HTTPSConnection") as mock_object:
-    yield mock_object
+	with patch.object(http.client, "HTTPSConnection") as mock_object:
+		yield mock_object
 
 @pytest.fixture
 def __mock_api_url():
-  with patch.object(urls, "API_URL", __API_URL):
-    yield
+	with patch.object(urls, "API_URL", __API_URL):
+		yield
 
 @pytest.fixture
 def __mock_timeout():
-  with patch("http.client.HTTPSConnection") as mock_method:
-    mock_method.side_effect = TimeoutError()
-    yield mock_method
+	with patch("http.client.HTTPSConnection") as mock_method:
+		mock_method.side_effect = TimeoutError()
+		yield mock_method
 
 @pytest.fixture
 def __mock_logger():
@@ -93,3 +103,19 @@ def __mock_logger_yellow():
 	) as mock_method:
 		mock_method.side_effect = lambda text: f"format-start-{text}-format-end"
 		yield mock_method
+
+@pytest.fixture
+def __mock_socket_available():
+	with patch("xmipp3_installer.api_client.api_client.socket.socket") as mock_socket:
+		with patch("xmipp3_installer.api_client.api_client.socket.setdefaulttimeout") as set_timeout:
+			instance = mock_socket.return_value.__enter__.return_value
+			instance.connect.return_value = None
+			yield mock_socket, set_timeout, instance
+
+
+@pytest.fixture
+def __mock_socket_unavailable():
+	with patch("xmipp3_installer.api_client.api_client.socket.socket") as mock_socket:
+		instance = mock_socket.return_value.__enter__.return_value
+		instance.connect.side_effect = OSError()
+		yield mock_socket

--- a/tests/unitary/installer/installer_service_test.py
+++ b/tests/unitary/installer/installer_service_test.py
@@ -342,6 +342,29 @@ def test_returns_interrupted_error_when_running_installer_and_user_interrupts_ex
     ret_code == errors.INTERRUPTED_ERROR
   ), get_assertion_message("return code", errors.INTERRUPTED_ERROR, ret_code)
 
+def test_does_not_send_installation_info_when_no_internet(
+  __mock_mode_executors,
+  __mock_get_installation_info,
+  __mock_send_installation_info,
+  __mock_logger,
+  __mock_internet_available
+):
+  __mock_mode_executors['all'](None).sends_installation_info = True
+  installation_manager = installer_service.InstallationManager({})
+  installation_manager.context = {
+    **installation_manager.context,
+    __SEND_INSTALLATION_INFO_KEY: True
+  }
+  __mock_internet_available.return_value = False
+
+  installation_manager.run_installer()
+
+  __mock_send_installation_info.assert_not_called()
+  __mock_logger.assert_called_once_with(
+    "No internet connection available. Installation info will not be sent.",
+    show_in_terminal=False
+  )
+
 def __mock_executor(ret_code, message):
   executor = MagicMock()
   executor.run.return_value = (ret_code, message)
@@ -438,6 +461,14 @@ def __mock_logger_close():
   with patch(
     "xmipp3_installer.application.logger.logger.Logger.close"
   ) as mock_method:
+    yield mock_method
+
+@pytest.fixture(autouse=True, params=[True])
+def __mock_internet_available(request):
+  with patch(
+    "xmipp3_installer.api_client.api_client.internet_available"
+  ) as mock_method:
+    mock_method.return_value = request.param
     yield mock_method
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
If installation statistics are enabled and there is no internet connection, the send process is cancelled and a message is displayed into the log only.