### PR TITLE
Fix 'distro' dependency version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.8"
 dependencies = [
   "typing-extensions==4.13.2; python_version < '3.9'",
   "typing-extensions==4.15.0; python_version >= '3.9'",
-  "distro==1.9.0"
+  "distro==1.8.0"
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xmipp3-installer"
-version = "2.1.1"
+version = "2.1.2"
 authors = [
   { name = "Martín Salinas", email = "ssalinasmartin@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.8"
 dependencies = [
   "typing-extensions==4.13.2; python_version < '3.9'",
   "typing-extensions==4.15.0; python_version >= '3.9'",
-  "distro==1.8.0"
+  "distro==1.8.0" # DO NOT UPGRADE UNTIL NEW SCIPION RELEASE SUPPORTS 1.9.0 VERSION
 ]
 
 [build-system]


### PR DESCRIPTION
Downgrade distro version to match scipion requirements. Updated the version of 'distro' dependency from 1.9.0 to 1.8.0.
Dont know which bot upgraded it, but we had to downgrade it time before:
https://github.com/I2PC/xmipp3-installer/commit/6a23bf7baae31b5af0d311cd28b930b775f0614d