### PR TITLE
Fix GitHub code quality findings from PR #226

### DIFF
--- a/src/xmipp3_installer/installer/installer_service.py
+++ b/src/xmipp3_installer/installer/installer_service.py
@@ -54,29 +54,31 @@ class InstallationManager:
     - (int): Return code.
     """
     try:
-      ret_code, output = self.mode_executor.run()
-    except KeyboardInterrupt:
-      logger.log_error("", ret_code=errors.INTERRUPTED_ERROR, add_portal_link=False)
-      return errors.INTERRUPTED_ERROR
-    if ret_code:
-      logger.log_error(output, ret_code=ret_code, add_portal_link=ret_code != errors.INTERRUPTED_ERROR)
-    if self._should_send_installation_info():
-      logger("Sending anonymous installation info...", show_in_terminal=False)
-      api_client.send_installation_attempt(
-        installation_info_assembler.get_installation_info(
-          self.context[constants.VERSIONS_CONTEXT_KEY],
-          ret_code=ret_code
+      try:
+        ret_code, output = self.mode_executor.run()
+      except KeyboardInterrupt:
+        logger.log_error("", ret_code=errors.INTERRUPTED_ERROR, add_portal_link=False)
+        return errors.INTERRUPTED_ERROR
+      if ret_code:
+        logger.log_error(output, ret_code=ret_code, add_portal_link=ret_code != errors.INTERRUPTED_ERROR)
+      if self._should_send_installation_info():
+        logger("Sending anonymous installation info...", show_in_terminal=False)
+        api_client.send_installation_attempt(
+          installation_info_assembler.get_installation_info(
+            self.context[constants.VERSIONS_CONTEXT_KEY],
+            ret_code=ret_code
+          )
         )
-      )
-    if not ret_code and self.mode_executor.prints_banner_on_exit:
-      logger(predefined_messages.get_success_message(
-        cast(
-          versions_manager.VersionsManager,
-          self.context[constants.VERSIONS_CONTEXT_KEY]
-        ).xmipp_version_name
-      ))
-    logger.close()
-    return ret_code
+      if not ret_code and self.mode_executor.prints_banner_on_exit:
+        logger(predefined_messages.get_success_message(
+          cast(
+            versions_manager.VersionsManager,
+            self.context[constants.VERSIONS_CONTEXT_KEY]
+          ).xmipp_version_name
+        ))
+      return ret_code
+    finally:
+      logger.close()
 
   def _should_send_installation_info(self) -> bool:
     """

--- a/src/xmipp3_installer/repository/config.py
+++ b/src/xmipp3_installer/repository/config.py
@@ -160,7 +160,6 @@ class ConfigurationFileHandler(Singleton):
     except InvalidConfigLineError as error:
       if self.show_errors:
         logger(str(error))
-      config = {}
       return None
     if key_value_pair:
       key, value = key_value_pair


### PR DESCRIPTION
- config.py: remove dead reassignment of the local `config` variable right before an unconditional `return None`; it had no effect since the caller already resets its own copy on error.
- installer_service.py: guarantee logger.close() runs via `finally`, so the log file gets closed even if mode_executor.run() raises something other than KeyboardInterrupt.