### PR TITLE
Fix 3 SonarQube findings on main

### DIFF
--- a/tests/unitary/api_client/assembler/installation_info_assembler_test.py
+++ b/tests/unitary/api_client/assembler/installation_info_assembler_test.py
@@ -582,7 +582,7 @@ def __mock_os_getenv(request):
 def __mock_os_is_linux(request):
   return getattr(request, 'param', True)
 
-@pytest.fixture()
+@pytest.fixture
 def __mock_platform_system(__mock_os_is_linux):
   with patch("platform.system") as mock_method:
     mock_method.return_value = __PLATFORM_SYSTEM_LINUX if __mock_os_is_linux else __PLATFORM_SYSTEM_WINDOWS

--- a/tests/unitary/installer/handlers/versions_manager_test.py
+++ b/tests/unitary/installer/handlers/versions_manager_test.py
@@ -132,8 +132,9 @@ def test_raises_value_error_when_validating_invalid_fields(
   __mock_init,
   expected_error_message
 ):
+  version_manager = VersionsManager(__FILE_PATH)
   with pytest.raises(ValueError) as error:
-    VersionsManager(__FILE_PATH)._validate_fields()
+    version_manager._validate_fields()
   error_message = str(error.value)
   assert (
     error_message == expected_error_message

--- a/tests/unitary/installer/installer_service_test.py
+++ b/tests/unitary/installer/installer_service_test.py
@@ -265,7 +265,7 @@ def test_calls_logger_to_send_installation_info_deppending_on_attribute_when_run
   "shows_message,__mock_mode_executors",
   [
     pytest.param(False, (1, 1)),
-    pytest.param(False, (1, 1)),
+    pytest.param(False, (0, 0)),
     pytest.param(True, (1, 1)),
     pytest.param(True, (0, 0))
   ],


### PR DESCRIPTION
- installer_service_test.py (S9078): the parametrize table had pytest.param(False, (1, 1)) duplicated instead of covering the missing shows_message=False/ret_code=0 case, leaving the AND condition's truth table incomplete.
- versions_manager_test.py (S5778): pytest.raises block wrapped both the VersionsManager(...) construction and the _validate_fields() call; split so only the call under test is inside the block (construction is a same-instance singleton fetch through a mocked __init__, so this is a clarity fix, not a behavior change).
- installation_info_assembler_test.py (S9083): drop empty parens on @pytest.fixture() for consistency with every other fixture in the file.

Left the 3 S3415 "swap assertion sides" findings unfixed: they all flag `(computed_tuple) == expected_param`, which is this codebase's consistent, deliberate assertion order (actual first, expected second, matching the get_assertion_message(item, expected, received) helper signature used throughout). Swapping them would contradict the project's own convention; most likely a false positive from Sonar's heuristic misreading a multi-line tuple literal as the "expected" side regardless of its contents.